### PR TITLE
bpftool: Continue iterating if individual map operations fail

### DIFF
--- a/tools/bpf/bpftool/map.c
+++ b/tools/bpf/bpftool/map.c
@@ -705,14 +705,14 @@ static int do_show(int argc, char **argv)
 				continue;
 			p_err("can't get map by id (%u): %s",
 			      id, strerror(errno));
-			break;
+			continue;
 		}
 
 		err = bpf_map_get_info_by_fd(fd, &info, &len);
 		if (err) {
 			p_err("can't get map info: %s", strerror(errno));
 			close(fd);
-			break;
+			continue;
 		}
 
 		if (json_output)


### PR DESCRIPTION
If a call to bpf_map_get_fd_by_id or bpf_map_get_info_by_fd fails, the current behavior is to bail out of the loop, which means no other maps can be displayed or modified. With this change, the loop will continue, so an error with one map will not affect the others.