### PR TITLE
libbpf: Fix theoretical u32 underflow in find_cd() function

### DIFF
--- a/tools/lib/bpf/zip.c
+++ b/tools/lib/bpf/zip.c
@@ -168,9 +168,8 @@ static int try_parse_end_of_cd(struct zip_archive *archive, __u32 offset)
 
 static int find_cd(struct zip_archive *archive)
 {
+	int64_t limit, offset;
 	int rc = -EINVAL;
-	int64_t limit;
-	__u32 offset;
 
 	if (archive->size <= sizeof(struct end_of_cd_record))
 		return -EINVAL;


### PR DESCRIPTION
Coverity reported a potential underflow of the offset variable used in the find_cd() function. Switch to using a signed 64 bit integer for the representation of offset to make sure we can never underflow.

Fixes: 1eebcb60633f ("libbpf: Implement basic zip archive parsing support")