### PR TITLE
bpf: Fix tr dereferencing

### DIFF
--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -3211,8 +3211,8 @@ static int bpf_tracing_prog_attach(struct bpf_prog *prog,
 		}
 
 		tr = bpf_trampoline_get(key, &tgt_info);
-		if (!tr) {
-			err = -ENOMEM;
+		if (IS_ERR(tr)) {
+			err = PTR_ERR(tr);
 			goto out_unlock;
 		}
 	} else {

--- a/kernel/bpf/trampoline.c
+++ b/kernel/bpf/trampoline.c
@@ -697,8 +697,8 @@ int bpf_trampoline_link_cgroup_shim(struct bpf_prog *prog,
 
 	bpf_lsm_find_cgroup_shim(prog, &bpf_func);
 	tr = bpf_trampoline_get(key, &tgt_info);
-	if (!tr)
-		return  -ENOMEM;
+	if (IS_ERR(tr))
+		return PTR_ERR(tr);
 
 	mutex_lock(&tr->mutex);
 
@@ -775,7 +775,7 @@ struct bpf_trampoline *bpf_trampoline_get(u64 key,
 
 	tr = bpf_trampoline_lookup(key);
 	if (!tr)
-		return NULL;
+		return ERR_PTR(-ENOMEM);
 
 	mutex_lock(&tr->mutex);
 	if (tr->func.addr)

--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -19771,8 +19771,8 @@ static int check_attach_btf_id(struct bpf_verifier_env *env)
 
 	key = bpf_trampoline_compute_key(tgt_prog, prog->aux->attach_btf, btf_id);
 	tr = bpf_trampoline_get(key, &tgt_info);
-	if (!tr)
-		return -ENOMEM;
+	if (IS_ERR(tr))
+		return PTR_ERR(tr);
 
 	if (tgt_prog && tgt_prog->aux->tail_call_reachable)
 		tr->flags = BPF_TRAMP_F_TAIL_CALL_CTX;


### PR DESCRIPTION
Fix 'tr' dereferencing bug when CONFIG_BPF_JIT is turned off.

Like 'bpf_trampoline_get_progs()', we can return 'ERR_PTR()' and then check by 'IS_ERR()'.

Fixes: 4a1e7c0c63e0 ("bpf: Support attaching freplace programs to multiple attach points")
Fixes: f7b12b6fea00 ("bpf: verifier: refactor check_attach_btf_id()")
Fixes: 69fd337a975c ("bpf: per-cgroup lsm flavor")
Reported-by: kernel test robot <lkp@intel.com>
Reported-by: Dan Carpenter <dan.carpenter@linaro.org>
Closes: https://lore.kernel.org/r/202309131936.5Nc8eUD0-lkp@intel.com/