### PR TITLE
bpf, arm64: Add support for lse atomics in bpf_arena

### DIFF
--- a/tools/testing/selftests/bpf/DENYLIST.aarch64
+++ b/tools/testing/selftests/bpf/DENYLIST.aarch64
@@ -10,4 +10,3 @@ fill_link_info/kprobe_multi_link_info            # bpf_program__attach_kprobe_mu
 fill_link_info/kretprobe_multi_link_info         # bpf_program__attach_kprobe_multi_opts unexpected error: -95
 fill_link_info/kprobe_multi_invalid_ubuff        # bpf_program__attach_kprobe_multi_opts unexpected error: -95
 missed/kprobe_recursion                          # missed_kprobe_recursion__attach unexpected error: -95 (errno 95)
-arena_atomics


### PR DESCRIPTION
When LSE atomics are available, BPF atomic instructions are implemented as single atomic instructions, therefore it is easy to enable these in bpf_arena using the currently available exception handling setup.

LL_SC atomics use loops and therefore would need more work to enable. Use the bpf_jit_supports_insn() callback to reject atomics in bpf_arena if LSE atomics are not available.

All atomics and arena_atomics selftests are passing:

[root@ip-172-31-2-216 bpf]# ./test_progs -a atomics,arena_atomics Summary: 2/14 PASSED, 0 SKIPPED, 0 FAILED