### PR TITLE
bpf: Set run context for rawtp test_run callback

### DIFF
--- a/net/bpf/test_run.c
+++ b/net/bpf/test_run.c
@@ -728,9 +728,7 @@ __bpf_prog_test_run_raw_tp(void *data)
 {
 	struct bpf_raw_tp_test_run_info *info = data;
 
-	rcu_read_lock();
-	info->retval = bpf_prog_run(info->prog, info->ctx);
-	rcu_read_unlock();
+	info->retval = bpf_prog_run_trace(info->prog, 0, info->ctx, bpf_prog_run);
 }
 
 int bpf_prog_test_run_raw_tp(struct bpf_prog *prog,


### PR DESCRIPTION
syzbot reported crash when rawtp program executed through the test_run interface calls bpf_get_attach_cookie helper or any other helper that touches task->bpf_ctx pointer.

We need to setup bpf_ctx pointer in rawtp test_run as well, so fixing this by moving __bpf_trace_run in header file and using it in test_run callback.

Also renaming __bpf_trace_run to bpf_prog_run_trace.

Reported-by: syzbot+3ab78ff125b7979e45f9@syzkaller.appspotmail.com