### PR TITLE
bpf: add memlock to struct bpf_map_info

### DIFF
--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -6607,6 +6607,7 @@ struct bpf_map_info {
 	__u32 btf_value_type_id;
 	__u32 btf_vmlinux_id;
 	__u64 map_extra;
+	__u64 memlock;
 } __attribute__((aligned(8)));
 
 struct bpf_btf_info {

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -4891,6 +4891,7 @@ static int bpf_map_get_info_by_fd(struct file *file,
 	info.max_entries = map->max_entries;
 	info.map_flags = map->map_flags;
 	info.map_extra = map->map_extra;
+	info.memlock = bpf_map_memory_usage(map);
 	memcpy(info.name, map->name, sizeof(map->name));
 
 	if (map->btf) {

--- a/tools/include/uapi/linux/bpf.h
+++ b/tools/include/uapi/linux/bpf.h
@@ -6607,6 +6607,7 @@ struct bpf_map_info {
 	__u32 btf_value_type_id;
 	__u32 btf_vmlinux_id;
 	__u64 map_extra;
+	__u64 memlock;
 } __attribute__((aligned(8)));
 
 struct bpf_btf_info {

--- a/tools/testing/selftests/bpf/prog_tests/bpf_obj_id.c
+++ b/tools/testing/selftests/bpf/prog_tests/bpf_obj_id.c
@@ -88,6 +88,7 @@ void serial_test_bpf_obj_id(void)
 				!ASSERT_EQ(map_infos[i].value_size, sizeof(__u64), "value_size") ||
 				!ASSERT_EQ(map_infos[i].max_entries, 1, "max_entries") ||
 				!ASSERT_EQ(map_infos[i].map_flags, 0, "map_flags") ||
+				!ASSERT_GT(map_infos[i].memlock, 0, "memlock") ||
 				!ASSERT_EQ(info_len, sizeof(struct bpf_map_info), "map_info_len") ||
 				!ASSERT_STREQ((char *)map_infos[i].name, expected_map_name, "map_name"))
 			goto done;


### PR DESCRIPTION
More accurate bpf map memory usage was added[^1] and commit 90a5527d7686d3ebe0dd2a831356a6c7d7dc31bc exposes the value only via bpf_map_show_fdinfo. Thus the information is missing from the structure returned from the BPF_OBJ_GET_INFO_BY_FD syscall command.

[^1]: https://lore.kernel.org/all/20230305124615.12358-1-laoar.shao@gmail.com/