### PR TITLE
selftests/bpf: use simply-expanded variables for libpcap flags

### DIFF
--- a/tools/testing/selftests/bpf/Makefile
+++ b/tools/testing/selftests/bpf/Makefile
@@ -48,9 +48,10 @@ CFLAGS += -g $(OPT_FLAGS) -rdynamic					\
 LDFLAGS += $(SAN_LDFLAGS)
 LDLIBS += $(LIBELF_LIBS) -lz -lrt -lpthread
 
-LDLIBS += $(shell $(PKG_CONFIG) --libs libpcap 2>/dev/null)
-CFLAGS += $(shell $(PKG_CONFIG) --cflags libpcap 2>/dev/null)
-CFLAGS += $(shell $(PKG_CONFIG) --exists libpcap 2>/dev/null && echo "-DTRAFFIC_MONITOR=1")
+PCAP_CFLAGS	:= $(shell $(PKG_CONFIG) --cflags libpcap 2>/dev/null && echo "-DTRAFFIC_MONITOR=1")
+PCAP_LIBS	:= $(shell $(PKG_CONFIG) --libs libpcap 2>/dev/null)
+LDLIBS += $(PCAP_LIBS)
+CFLAGS += $(PCAP_CFLAGS)
 
 # The following tests perform type punning and they may break strict
 # aliasing rules, which are exploited by both GCC and clang by default


### PR DESCRIPTION
Save output of pkg-conf for libpcap as simply-expanded variables. For an obscure reason, having LDLIBS/CFLAGS recursively expanded variables with 'shell' call makes *.test.o files compilation non-parallel when make is executed with -j option.

While at it, reuse 'pkg-conf --cflags' call to define -DTRAFFIC_MONITOR=1 option, it's exit status is the same as for 'pkg-conf --exists'.

Fixes: f52403b6bfea ("selftests/bpf: Add traffic monitor functions.")