### PR TITLE
bpf: Two tailcall improvements

### DIFF
--- a/arch/x86/net/bpf_jit_comp.c
+++ b/arch/x86/net/bpf_jit_comp.c
@@ -2124,10 +2124,12 @@ populate_extable:
 
 			/* call */
 		case BPF_JMP | BPF_CALL: {
+			bool pseudo_call = src_reg == BPF_PSEUDO_CALL;
+			bool subprog_tail_call_reachable = dst_reg;
 			u8 *ip = image + addrs[i - 1];
 
 			func = (u8 *) __bpf_call_base + imm32;
-			if (tail_call_reachable) {
+			if (pseudo_call && subprog_tail_call_reachable) {
 				LOAD_TAIL_CALL_CNT_PTR(bpf_prog->aux->stack_depth);
 				ip += 7;
 			}

--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -19990,6 +19990,12 @@ static int jit_subprogs(struct bpf_verifier_env *env)
 			insn[0].imm = (u32)addr;
 			insn[1].imm = addr >> 32;
 		}
+
+		/* In the x86_64 JIT, tailcall information can only be
+		 * propagated if the subprog is tail_call_reachable.
+		 */
+		insn->dst_reg = bpf_pseudo_call(insn) ?
+				env->subprog_info[subprog].tail_call_reachable : 0;
 	}
 
 	err = bpf_prog_alloc_jited_linfo(prog);


### PR DESCRIPTION
In the x86_64 JIT, when calling a function, tailcall info is propagated if
the program is tail_call_reachable, regardless of whether the function is a
subprog, helper, or kfunc. However, this propagation is unnecessary for
not-tail_call_reachable subprogs, helpers, or kfuncs.

The verifier can determine if a subprog is tail_call_reachable. Therefore,
it can be optimized to only propagate tailcall info when the callee is
subprog and the subprog is actually tail_call_reachable.

Signed-off-by: Leon Hwang <leon.hwang@linux.dev>