### PR TITLE
Bpf blinding

### DIFF
--- a/include/linux/filter.h
+++ b/include/linux/filter.h
@@ -1297,11 +1297,12 @@ static inline bool bpf_jit_blinding_enabled(struct bpf_prog *prog)
 	 */
 	if (!bpf_jit_is_ebpf())
 		return false;
-	if (!prog->jit_requested)
+	if (prog && !prog->jit_requested)
 		return false;
 	if (!bpf_jit_harden)
 		return false;
-	if (bpf_jit_harden == 1 && bpf_token_capable(prog->aux->token, CAP_BPF))
+	if (bpf_jit_harden == 1 &&
+	    bpf_token_capable(prog ? prog->aux->token : NULL, CAP_BPF))
 		return false;
 
 	return true;

--- a/kernel/bpf/core.c
+++ b/kernel/bpf/core.c
@@ -570,6 +570,9 @@ int bpf_jit_kallsyms __read_mostly = IS_BUILTIN(CONFIG_BPF_JIT_DEFAULT_ON);
 int bpf_jit_harden   __read_mostly;
 long bpf_jit_limit   __read_mostly;
 long bpf_jit_limit_max __read_mostly;
+#if IS_MODULE(CONFIG_TEST_BPF)
+EXPORT_SYMBOL_GPL(bpf_jit_harden);
+#endif
 
 static void
 bpf_prog_ksym_set_addr(struct bpf_prog *prog)

--- a/kernel/bpf/token.c
+++ b/kernel/bpf/token.c
@@ -26,6 +26,9 @@ bool bpf_token_capable(const struct bpf_token *token, int cap)
 		return false;
 	return true;
 }
+#if IS_MODULE(CONFIG_TEST_BPF)
+EXPORT_SYMBOL_GPL(bpf_token_capable);
+#endif
 
 void bpf_token_inc(struct bpf_token *token)
 {

--- a/lib/test_bpf.c
+++ b/lib/test_bpf.c
@@ -491,7 +491,7 @@ static int __bpf_fill_max_jmp(struct bpf_test *self, int jmp, int imm)
 	i = __bpf_ld_imm64(insns, R1, 0x0123456789abcdefULL);
 	insns[i++] = BPF_ALU64_IMM(BPF_MOV, R0, 1);
 	insns[i++] = BPF_JMP_IMM(jmp, R0, imm, S16_MAX);
-	insns[i++] = BPF_ALU64_IMM(BPF_MOV, R0, 2);
+	insns[i++] = BPF_ALU64_REG(BPF_ADD, R0, R0);
 	insns[i++] = BPF_EXIT_INSN();
 
 	while (i < len - 1) {


### PR DESCRIPTION
Fix failing tests under BPF constant blinding.

Before:
```shell-session
root@box:~# sysctl net.core.bpf_jit_harden=2
root@box:~# insmod test_bpf.ko
insmod: ERROR: could not insert module test_bpf.ko: Invalid parameters
root@box:~# dmesg | grep Summary
[  177.628099] test_bpf: Summary: 1000 PASSED, 49 FAILED, [988/988 JIT'ed]
```

After:
```shell-session
root@box:~# sysctl net.core.bpf_jit_harden=2
root@box:~# insmod test_bpf.ko
root@box:~# dmesg | grep Summary
[  220.437597] test_bpf: Summary: 1049 PASSED, 0 FAILED, [1037/1037 JIT'ed]
[  220.477987] test_bpf: test_tail_calls: Summary: 10 PASSED, 0 FAILED, [10/10 JIT'ed]
[  220.480525] test_bpf: test_skb_segment: Summary: 2 PASSED, 0 FAILED
```