### PR TITLE
selftests/bpf: make BPF_TARGET_ENDIAN non-recursive to speed up *.bpf…

### DIFF
--- a/tools/testing/selftests/bpf/Makefile
+++ b/tools/testing/selftests/bpf/Makefile
@@ -461,10 +461,10 @@ $(shell $(1) $(2) -dM -E - </dev/null | grep -E 'MIPS(EL|EB)|_MIPS_SZ(PTR|LONG) 
 endef
 
 # Determine target endianness.
-IS_LITTLE_ENDIAN = $(shell $(CC) -dM -E - </dev/null | \
+IS_LITTLE_ENDIAN := $(shell $(CC) -dM -E - </dev/null | \
 			grep 'define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__')
-MENDIAN=$(if $(IS_LITTLE_ENDIAN),-mlittle-endian,-mbig-endian)
-BPF_TARGET_ENDIAN=$(if $(IS_LITTLE_ENDIAN),--target=bpfel,--target=bpfeb)
+MENDIAN:=$(if $(IS_LITTLE_ENDIAN),-mlittle-endian,-mbig-endian)
+BPF_TARGET_ENDIAN:=$(if $(IS_LITTLE_ENDIAN),--target=bpfel,--target=bpfeb)
 
 ifneq ($(CROSS_COMPILE),)
 CLANG_TARGET_ARCH = --target=$(notdir $(CROSS_COMPILE:%-=%))


### PR DESCRIPTION
….o build

BPF_TARGET_ENDIAN is used in CLANG_BPF_BUILD_RULE and co macro. It is defined as a recursively expanded variable, meaning that it is recomputed each time the value is needed, in other words, for each *.bpf.o file compilation. The variable is computed by running a C compiler in a shell. This significantly hinders parallel build performance for *.bpf.o files.

This commit changes BPF_TARGET_ENDIAN to be a simple variable.

    # Build performance stats before this commit
    $ git clean -xfd; time make -j12
    real	1m0.000s
    ...

    # Build performance stats after this commit
    $ git clean -xfd; time make -j12
    real	0m43.605s
    ...