### PR TITLE
libbpf: Fix inheritance of BTF pointer size

### DIFF
--- a/tools/lib/bpf/btf.c
+++ b/tools/lib/bpf/btf.c
@@ -995,6 +995,7 @@ static struct btf *btf_new_empty(struct btf *base_btf)
 
 	if (base_btf) {
 		btf->base_btf = base_btf;
+		btf->ptr_sz = base_btf->ptr_sz;
 		btf->start_id = btf__type_cnt(base_btf);
 		btf->start_str_off = base_btf->hdr->str_len + base_btf->start_str_off;
 		btf->swapped_endian = base_btf->swapped_endian;


### PR DESCRIPTION
Update btf_new_empty() to copy the pointer size from a provided base BTF. This ensures split BTF works properly and fixes test failures seen on 32-bit targets:

  root@qemu-armhf:/usr/libexec/kselftests-bpf# ./test_progs -a btf_split
  __test_btf_split:PASS:empty_main_btf 0 nsec
  __test_btf_split:PASS:main_ptr_sz 0 nsec
  __test_btf_split:PASS:empty_split_btf 0 nsec
  __test_btf_split:FAIL:inherit_ptr_sz unexpected inherit_ptr_sz: actual 4 != expected 8
  [...]
  #41/1    btf_split/single_split:FAIL

Fixes: ba451366bf44 ("libbpf: Implement basic split BTF support")