### PR TITLE
selftests/bpf: include limits.h needed for PATH_MAX directly

### DIFF
--- a/tools/testing/selftests/bpf/unpriv_helpers.c
+++ b/tools/testing/selftests/bpf/unpriv_helpers.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Constant PATH_MAX is used in function unpriv_helpers.c:open_config(). This constant is provided by include file <limits.h>. The dependency was added by commit [1], which does not include <limits.h> directly, relying instead on <limits.h> being included from zlib.h -> zconf.h. As it turns out, this is not the case for all systems, e.g. on Fedora 41 zlib 1.3.1 is used, and there <limits.h> is not included from zconf.h. Hence, there is a compilation error on Fedora 41.

[1] commit fc2915bb8bfc ("selftests/bpf: More precise cpu_mitigations state detection")

Fixes: commit fc2915bb8bfc ("selftests/bpf: More precise cpu_mitigations state detection")