### PR TITLE
bpf: Check the helper function is valid in get_helper_proto

### DIFF
--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -11344,6 +11344,13 @@ static bool can_elide_value_nullness(enum bpf_map_type type)
 	}
 }
 
+static bool is_valid_proto(const struct bpf_func_proto *fn)
+{
+	if (fn == &bpf_tail_call_proto)
+		return true;
+	return fn && fn->func;
+}
+
 static int get_helper_proto(struct bpf_verifier_env *env, int func_id,
 			    const struct bpf_func_proto **ptr)
 {
@@ -11354,7 +11361,7 @@ static int get_helper_proto(struct bpf_verifier_env *env, int func_id,
 		return -EINVAL;
 
 	*ptr = env->ops->get_func_proto(func_id, env->prog);
-	return *ptr ? 0 : -EINVAL;
+	return is_valid_proto(*ptr) ? 0 : -EINVAL;
 }
 
 static int check_helper_call(struct bpf_verifier_env *env, struct bpf_insn *insn,


### PR DESCRIPTION
syzbot reported an verifier bug [1] where the helper func pointer could be NULL due to disabled config option.

As Alexei suggested we could check on that in get_helper_proto directly. Excluding tail_call helper from the check, because it is NULL by design and valid in all configs.

[1] https://lore.kernel.org/bpf/68904050.050a0220.7f033.0001.GAE@google.com/
Reported-by: syzbot+a9ed3d9132939852d0df@syzkaller.appspotmail.com
Suggested-by: Alexei Starovoitov <ast@kernel.org>