### PR TITLE
bpf: Check the helper function is valid in get_helper_proto

### DIFF
--- a/kernel/bpf/core.c
+++ b/kernel/bpf/core.c
@@ -3024,7 +3024,9 @@ EXPORT_SYMBOL_GPL(bpf_event_output);
 
 /* Always built-in helper functions. */
 const struct bpf_func_proto bpf_tail_call_proto = {
-	.func		= NULL,
+	/* func is unused for tail_call, we set it != NULL to pass the
+	 * get_helper_proto check */
+	.func		= (void *) 1,
 	.gpl_only	= false,
 	.ret_type	= RET_VOID,
 	.arg1_type	= ARG_PTR_TO_CTX,

--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -11354,7 +11354,7 @@ static int get_helper_proto(struct bpf_verifier_env *env, int func_id,
 		return -EINVAL;
 
 	*ptr = env->ops->get_func_proto(func_id, env->prog);
-	return *ptr ? 0 : -EINVAL;
+	return *ptr && (*ptr)->func ? 0 : -EINVAL;
 }
 
 static int check_helper_call(struct bpf_verifier_env *env, struct bpf_insn *insn,


### PR DESCRIPTION
syzbot reported an verifier bug [1] where the helper func pointer could be NULL due to disabled config option.

As Alexei suggested we could check on that in get_helper_proto directly. Excluding tail_call helper from the check, because it is NULL by design and valid in all configs.

[1] https://lore.kernel.org/bpf/68904050.050a0220.7f033.0001.GAE@google.com/
Reported-by: syzbot+a9ed3d9132939852d0df@syzkaller.appspotmail.com
Suggested-by: Alexei Starovoitov <ast@kernel.org>