### PR TITLE
Revert "perf/x86: Always store regs->ip in perf_callchain_kernel()"

### DIFF
--- a/arch/x86/events/core.c
+++ b/arch/x86/events/core.c
@@ -2787,13 +2787,13 @@ perf_callchain_kernel(struct perf_callchain_entry_ctx *entry, struct pt_regs *re
 		return;
 	}
 
-	if (perf_callchain_store(entry, regs->ip))
-		return;
-
-	if (perf_hw_regs(regs))
+	if (perf_hw_regs(regs)) {
+		if (perf_callchain_store(entry, regs->ip))
+			return;
 		unwind_start(&state, current, regs, NULL);
-	else
+	} else {
 		unwind_start(&state, current, NULL, (void *)regs->sp);
+	}
 
 	for (; !unwind_done(&state); unwind_next_frame(&state)) {
 		addr = unwind_get_return_address(&state);


### PR DESCRIPTION
This reverts commit 83f44ae0f8afcc9da659799db8693f74847e66b3.

hi,
non hw events store first stack trace entry twice,

        bpf_prog_2beb79c650d605dd_rawtracepoint_sched_process_exec_1+324
        bpf_prog_2beb79c650d605dd_rawtracepoint_sched_process_exec_1+324
        bpf_trace_run3+138
        bprm_execve+1191
        do_execveat_common.isra.0+404
        __x64_sys_execve+56
        do_syscall_64+130
        entry_SYSCALL_64_after_hwframe+118

I traced it to [1] from 2019, which stores regs->ip implicitly to fix raw tracepoints stacktrace. Revert does not seem to break raw tp stacktrace for me. Song, any idea? I know it's long time ;-)

thanks,
jirka

[1] 83f44ae0f8af ("perf/x86: Always store regs->ip in perf_callchain_kernel()")