### PR TITLE
selftests/bpf: trigger bug in list_del()

### DIFF
--- a/tools/testing/selftests/bpf/progs/arena_list.c
+++ b/tools/testing/selftests/bpf/progs/arena_list.c
@@ -76,7 +76,7 @@ int arena_list_del(void *ctx)
 		sum += n->value;
 		arena_sum += n->value;
 		list_del(&n->node);
-		bpf_free(n);
+		//bpf_free(n);
 	}
 	list_sum = sum;
 #else


### PR DESCRIPTION
Comment out the bpf_free() from arena_list_del() so the nodes are removed
by list_del() but the memory is not freed, this will trigger a bug showing
that list_del is doesn't remove nodes and just poisons the next and pprev
pointers.