### PR TITLE
scripts/gen-btf.sh: Fix .btf.o generation when compiling for RISCV

### DIFF
--- a/scripts/gen-btf.sh
+++ b/scripts/gen-btf.sh
@@ -96,7 +96,7 @@ gen_btf_o()
 	# deletes all symbols including __start_BTF and __stop_BTF, which will
 	# be redefined in the linker script.
 	info OBJCOPY "${btf_data}"
-	echo "" | ${CC} ${CLANG_FLAGS} -c -x c -o ${btf_data} -
+	echo "" | ${CC} ${CLANG_FLAGS} ${KBUILD_CFLAGS} -c -x c -o ${btf_data} -
 	${OBJCOPY} --add-section .BTF=${ELF_FILE}.BTF \
 		--set-section-flags .BTF=alloc,readonly ${btf_data}
 	${OBJCOPY} --only-section=.BTF --strip-all ${btf_data}


### PR DESCRIPTION
gen-btf.sh emits a .btf.o file with BTF sections to be linked into vmlinux in link-vmlinux.sh

This .btf.o file is created by compiling an emptystring with ${CC}, and then adding BTF sections into it with ${OBJCOPY}.

To ensure the .btf.o is linkable when cross-compiling with LLVM, we have to also pass ${KBUILD_FLAGS}, which in particular control the target word size.

Reported-by: kernel test robot <lkp@intel.com>
Closes: https://lore.kernel.org/oe-kbuild-all/202512240559.2M06DSX7-lkp@intel.com/