### PR TITLE
bpf: Fix mmap_lock deadlock in VMA iterators using per-VMA locks

### DIFF
--- a/kernel/bpf/task_iter.c
+++ b/kernel/bpf/task_iter.c
@@ -429,68 +429,18 @@ task_vma_seq_get_next(struct bpf_iter_seq_task_vma_info *info)
 	struct vm_area_struct *curr_vma;
 	struct task_struct *curr_task;
 	struct mm_struct *curr_mm;
+	struct vma_iterator vmi;
 	u32 saved_tid = info->tid;
 
-	/* If this function returns a non-NULL vma, it holds a reference to
-	 * the task_struct, holds a refcount on mm->mm_users, and holds
-	 * read lock on vma->mm->mmap_lock.
-	 * If this function returns NULL, it does not hold any reference or
-	 * lock.
-	 */
 	if (info->task) {
 		curr_task = info->task;
 		curr_vma = info->vma;
 		curr_mm = info->mm;
-		/* In case of lock contention, drop mmap_lock to unblock
-		 * the writer.
-		 *
-		 * After relock, call find(mm, prev_vm_end - 1) to find
-		 * new vma to process.
-		 *
-		 *   +------+------+-----------+
-		 *   | VMA1 | VMA2 | VMA3      |
-		 *   +------+------+-----------+
-		 *   |      |      |           |
-		 *  4k     8k     16k         400k
-		 *
-		 * For example, curr_vma == VMA2. Before unlock, we set
-		 *
-		 *    prev_vm_start = 8k
-		 *    prev_vm_end   = 16k
-		 *
-		 * There are a few cases:
-		 *
-		 * 1) VMA2 is freed, but VMA3 exists.
-		 *
-		 *    find_vma() will return VMA3, just process VMA3.
-		 *
-		 * 2) VMA2 still exists.
-		 *
-		 *    find_vma() will return VMA2, process VMA2->next.
-		 *
-		 * 3) no more vma in this mm.
-		 *
-		 *    Process the next task.
-		 *
-		 * 4) find_vma() returns a different vma, VMA2'.
-		 *
-		 *    4.1) If VMA2 covers same range as VMA2', skip VMA2',
-		 *         because we already covered the range;
-		 *    4.2) VMA2 and VMA2' covers different ranges, process
-		 *         VMA2'.
-		 */
-		if (mmap_lock_is_contended(curr_mm)) {
-			info->prev_vm_start = curr_vma->vm_start;
-			info->prev_vm_end = curr_vma->vm_end;
-			op = task_vma_iter_find_vma;
-			mmap_read_unlock(curr_mm);
-			if (mmap_read_lock_killable(curr_mm)) {
-				mmput(curr_mm);
-				goto finish;
-			}
-		} else {
-			op = task_vma_iter_next_vma;
-		}
+
+		info->prev_vm_start = curr_vma->vm_start;
+		info->prev_vm_end = curr_vma->vm_end;
+
+		op = task_vma_iter_find_vma;
 	} else {
 again:
 		curr_task = task_seq_get_next(&info->common, &info->tid, true);
@@ -499,57 +449,88 @@ again:
 			goto finish;
 		}
 
-		if (saved_tid != info->tid) {
-			/* new task, process the first vma */
+		if (saved_tid != info->tid)
 			op = task_vma_iter_first_vma;
-		} else {
-			/* Found the same tid, which means the user space
-			 * finished data in previous buffer and read more.
-			 * We dropped mmap_lock before returning to user
-			 * space, so it is necessary to use find_vma() to
-			 * find the next vma to process.
-			 */
+		else
 			op = task_vma_iter_find_vma;
-		}
 
 		curr_mm = get_task_mm(curr_task);
 		if (!curr_mm)
 			goto next_task;
+	}
 
-		if (mmap_read_lock_killable(curr_mm)) {
+	/* Find and validate VMA using per-VMA locks */
+	{
+		unsigned long addr, vm_start;
+		struct vm_area_struct *locked_vma;
+
+		switch (op) {
+		case task_vma_iter_first_vma:
+			addr = 0;
+			break;
+		case task_vma_iter_find_vma:
+			addr = info->prev_vm_end - 1;
+			break;
+		case task_vma_iter_next_vma:
+			WARN_ON_ONCE(1);
 			mmput(curr_mm);
-			goto finish;
+			goto next_task;
 		}
-	}
 
-	switch (op) {
-	case task_vma_iter_first_vma:
-		curr_vma = find_vma(curr_mm, 0);
-		break;
-	case task_vma_iter_next_vma:
-		curr_vma = find_vma(curr_mm, curr_vma->vm_end);
-		break;
-	case task_vma_iter_find_vma:
-		/* We dropped mmap_lock so it is necessary to use find_vma
-		 * to find the next vma. This is similar to the  mechanism
-		 * in show_smaps_rollup().
+		/* Find VMA under RCU, then validate with per-VMA lock.
+		 * We release the lock before returning to avoid lock ordering issues.
 		 */
-		curr_vma = find_vma(curr_mm, info->prev_vm_end - 1);
-		/* case 1) and 4.2) above just use curr_vma */
+		rcu_read_lock();
+		vma_iter_init(&vmi, curr_mm, addr);
+		curr_vma = vma_next(&vmi);
+		if (!curr_vma) {
+			rcu_read_unlock();
+			mmput(curr_mm);
+			goto next_task;
+		}
+		vm_start = curr_vma->vm_start;
+		rcu_read_unlock();
 
-		/* check for case 2) or case 4.1) above */
-		if (curr_vma &&
-		    curr_vma->vm_start == info->prev_vm_start &&
-		    curr_vma->vm_end == info->prev_vm_end)
-			curr_vma = find_vma(curr_mm, curr_vma->vm_end);
-		break;
+		/* Validate the VMA with per-VMA lock */
+		locked_vma = lock_vma_under_rcu(curr_mm, vm_start);
+		if (!locked_vma) {
+			mmput(curr_mm);
+			goto next_task;
+		}
+
+		/* Check for duplicate VMA */
+		if (op == task_vma_iter_find_vma &&
+		    locked_vma->vm_start == info->prev_vm_start &&
+		    locked_vma->vm_end == info->prev_vm_end) {
+			unsigned long next_start;
+
+			/* Skip duplicate - find next VMA */
+			next_start = locked_vma->vm_end;
+			vma_end_read(locked_vma);
+
+			rcu_read_lock();
+			vma_iter_set(&vmi, next_start);
+			curr_vma = vma_next(&vmi);
+			if (!curr_vma) {
+				rcu_read_unlock();
+				mmput(curr_mm);
+				goto next_task;
+			}
+			vm_start = curr_vma->vm_start;
+			rcu_read_unlock();
+
+			locked_vma = lock_vma_under_rcu(curr_mm, vm_start);
+			if (!locked_vma) {
+				mmput(curr_mm);
+				goto next_task;
+			}
+		}
+
+		/* We have a valid VMA - release lock before returning */
+		curr_vma = locked_vma;
+		vma_end_read(locked_vma);
 	}
-	if (!curr_vma) {
-		/* case 3) above, or case 2) 4.1) with vma->next == NULL */
-		mmap_read_unlock(curr_mm);
-		mmput(curr_mm);
-		goto next_task;
-	}
+
 	info->task = curr_task;
 	info->vma = curr_vma;
 	info->mm = curr_mm;
@@ -642,7 +623,7 @@ static void task_vma_seq_stop(struct seq_file *seq, void *v)
 		 */
 		info->prev_vm_start = ~0UL;
 		info->prev_vm_end = info->vma->vm_end;
-		mmap_read_unlock(info->mm);
+
 		mmput(info->mm);
 		info->mm = NULL;
 		put_task_struct(info->task);
@@ -751,9 +732,7 @@ static struct bpf_iter_reg task_vma_reg_info = {
 BPF_CALL_5(bpf_find_vma, struct task_struct *, task, u64, start,
 	   bpf_callback_t, callback_fn, void *, callback_ctx, u64, flags)
 {
-	struct mmap_unlock_irq_work *work = NULL;
 	struct vm_area_struct *vma;
-	bool irq_work_busy = false;
 	struct mm_struct *mm;
 	int ret = -ENOENT;
 
@@ -767,19 +746,34 @@ BPF_CALL_5(bpf_find_vma, struct task_struct *, task, u64, start,
 	if (!mm)
 		return -ENOENT;
 
-	irq_work_busy = bpf_mmap_unlock_get_irq_work(&work);
+	/* Find and validate VMA under RCU without holding locks during callback.
+	 * We cannot hold vm_lock or mmap_lock during the callback because the
+	 * callback may call bpf_copy_from_user_task() which needs mmap_lock,
+	 * creating a lock ordering violation with the kernel's mmap_lock->vm_lock
+	 * dependency.
+	 */
+	rcu_read_lock();
+	vma = lock_vma_under_rcu(mm, start);
+	if (!vma) {
+		rcu_read_unlock();
+		return -ENOENT;
+	}
 
-	if (irq_work_busy || !mmap_read_trylock(mm))
-		return -EBUSY;
-
-	vma = find_vma(mm, start);
-
-	if (vma && vma->vm_start <= start && vma->vm_end > start) {
+	/* Validate VMA covers the address while we hold the lock */
+	if (vma->vm_start <= start && vma->vm_end > start) {
+		/* VMA is valid - release lock before callback to avoid lock ordering issues.
+		 * The VMA structure is RCU-protected so it won't be freed, but fields
+		 * might change. This is acceptable for BPF tracing/profiling use cases.
+		 */
+		vma_end_read(vma);
 		callback_fn((u64)(long)task, (u64)(long)vma,
 			    (u64)(long)callback_ctx, 0, 0);
 		ret = 0;
+	} else {
+		vma_end_read(vma);
 	}
-	bpf_mmap_unlock_mm(work, mm);
+	rcu_read_unlock();
+
 	return ret;
 }
 
@@ -797,8 +791,8 @@ const struct bpf_func_proto bpf_find_vma_proto = {
 struct bpf_iter_task_vma_kern_data {
 	struct task_struct *task;
 	struct mm_struct *mm;
-	struct mmap_unlock_irq_work *work;
 	struct vma_iterator vmi;
+	unsigned long prev_vm_end;
 };
 
 struct bpf_iter_task_vma {
@@ -819,16 +813,11 @@ __bpf_kfunc int bpf_iter_task_vma_new(struct bpf_iter_task_vma *it,
 				      struct task_struct *task, u64 addr)
 {
 	struct bpf_iter_task_vma_kern *kit = (void *)it;
-	bool irq_work_busy = false;
 	int err;
 
 	BUILD_BUG_ON(sizeof(struct bpf_iter_task_vma_kern) != sizeof(struct bpf_iter_task_vma));
 	BUILD_BUG_ON(__alignof__(struct bpf_iter_task_vma_kern) != __alignof__(struct bpf_iter_task_vma));
 
-	/* is_iter_reg_valid_uninit guarantees that kit hasn't been initialized
-	 * before, so non-NULL kit->data doesn't point to previously
-	 * bpf_mem_alloc'd bpf_iter_task_vma_kern_data
-	 */
 	kit->data = bpf_mem_alloc(&bpf_global_ma, sizeof(struct bpf_iter_task_vma_kern_data));
 	if (!kit->data)
 		return -ENOMEM;
@@ -840,21 +829,15 @@ __bpf_kfunc int bpf_iter_task_vma_new(struct bpf_iter_task_vma *it,
 		goto err_cleanup_iter;
 	}
 
-	/* kit->data->work == NULL is valid after bpf_mmap_unlock_get_irq_work */
-	irq_work_busy = bpf_mmap_unlock_get_irq_work(&kit->data->work);
-	if (irq_work_busy || !mmap_read_trylock(kit->data->mm)) {
-		err = -EBUSY;
-		goto err_cleanup_iter;
-	}
-
 	vma_iter_init(&kit->data->vmi, kit->data->mm, addr);
+	kit->data->prev_vm_end = addr;
+
 	return 0;
 
 err_cleanup_iter:
 	if (kit->data->task)
 		put_task_struct(kit->data->task);
 	bpf_mem_free(&bpf_global_ma, kit->data);
-	/* NULL kit->data signals failed bpf_iter_task_vma initialization */
 	kit->data = NULL;
 	return err;
 }
@@ -862,10 +845,37 @@ err_cleanup_iter:
 __bpf_kfunc struct vm_area_struct *bpf_iter_task_vma_next(struct bpf_iter_task_vma *it)
 {
 	struct bpf_iter_task_vma_kern *kit = (void *)it;
+	struct vm_area_struct *vma;
+	unsigned long vm_start;
 
-	if (!kit->data) /* bpf_iter_task_vma_new failed */
+	if (!kit->data)
 		return NULL;
-	return vma_next(&kit->data->vmi);
+
+	/* Find next VMA under RCU, then validate it with per-VMA lock.
+	 * We release the lock before returning to avoid lock ordering issues
+	 * if the BPF program calls bpf_copy_from_user_task().
+	 */
+	rcu_read_lock();
+	vma_iter_set(&kit->data->vmi, kit->data->prev_vm_end);
+	vma = vma_next(&kit->data->vmi);
+	if (!vma) {
+		rcu_read_unlock();
+		return NULL;
+	}
+	vm_start = vma->vm_start;
+	rcu_read_unlock();
+
+	/* Validate and lock the VMA we found */
+	vma = lock_vma_under_rcu(kit->data->mm, vm_start);
+	if (!vma)
+		return NULL;
+
+	/* Save end address for next iteration, then release lock */
+	kit->data->prev_vm_end = vma->vm_end;
+	vma_end_read(vma);
+
+	/* Return VMA without holding locks - RCU protects from being freed */
+	return vma;
 }
 
 __bpf_kfunc void bpf_iter_task_vma_destroy(struct bpf_iter_task_vma *it)
@@ -873,7 +883,6 @@ __bpf_kfunc void bpf_iter_task_vma_destroy(struct bpf_iter_task_vma *it)
 	struct bpf_iter_task_vma_kern *kit = (void *)it;
 
 	if (kit->data) {
-		bpf_mmap_unlock_mm(kit->data->work, kit->data->mm);
 		put_task_struct(kit->data->task);
 		bpf_mem_free(&bpf_global_ma, kit->data);
 	}


### PR DESCRIPTION
BPF VMA iterators and bpf_find_vma() hold mmap_lock, which deadlocks when BPF programs call bpf_copy_from_user_task() on the same task (recursive lock acquisition).

Holding per-VMA locks during BPF execution also deadlocks due to circular locking: kernel has mmap_lock → vm_lock dependency (vma_expand), our code creates vm_lock → mmap_lock (callback → bpf_copy_from_user_task).

Solution: Use per-VMA locks to validate VMAs are stable, then release vm_lock BEFORE returning to BPF or calling callbacks. VMA structures remain RCU-protected during BPF execution.

Trade-off: VMA fields may be stale between lock release and BPF access. This is acceptable for tracing/profiling use cases.