### PR TITLE
bpf: Remove mmap_lock from task_vma iterator to prevent deadlock

### DIFF
--- a/kernel/bpf/task_iter.c
+++ b/kernel/bpf/task_iter.c
@@ -797,8 +797,7 @@ const struct bpf_func_proto bpf_find_vma_proto = {
 struct bpf_iter_task_vma_kern_data {
 	struct task_struct *task;
 	struct mm_struct *mm;
-	struct mmap_unlock_irq_work *work;
-	struct vma_iterator vmi;
+	unsigned long next_addr;
 };
 
 struct bpf_iter_task_vma {
@@ -819,7 +818,6 @@ __bpf_kfunc int bpf_iter_task_vma_new(struct bpf_iter_task_vma *it,
 				      struct task_struct *task, u64 addr)
 {
 	struct bpf_iter_task_vma_kern *kit = (void *)it;
-	bool irq_work_busy = false;
 	int err;
 
 	BUILD_BUG_ON(sizeof(struct bpf_iter_task_vma_kern) != sizeof(struct bpf_iter_task_vma));
@@ -840,14 +838,7 @@ __bpf_kfunc int bpf_iter_task_vma_new(struct bpf_iter_task_vma *it,
 		goto err_cleanup_iter;
 	}
 
-	/* kit->data->work == NULL is valid after bpf_mmap_unlock_get_irq_work */
-	irq_work_busy = bpf_mmap_unlock_get_irq_work(&kit->data->work);
-	if (irq_work_busy || !mmap_read_trylock(kit->data->mm)) {
-		err = -EBUSY;
-		goto err_cleanup_iter;
-	}
-
-	vma_iter_init(&kit->data->vmi, kit->data->mm, addr);
+	kit->data->next_addr = addr;
 	return 0;
 
 err_cleanup_iter:
@@ -862,10 +853,23 @@ err_cleanup_iter:
 __bpf_kfunc struct vm_area_struct *bpf_iter_task_vma_next(struct bpf_iter_task_vma *it)
 {
 	struct bpf_iter_task_vma_kern *kit = (void *)it;
+	struct vm_area_struct *vma;
+	struct vma_iterator vmi;
 
 	if (!kit->data) /* bpf_iter_task_vma_new failed */
 		return NULL;
-	return vma_next(&kit->data->vmi);
+
+	vma_iter_init(&vmi, kit->data->mm, kit->data->next_addr);
+	rcu_read_lock();
+	vma = vma_next(&vmi);
+	/* Verify VMA still belongs to our mm */
+	if (vma && vma->vm_mm == kit->data->mm)
+		kit->data->next_addr = vma->vm_end;
+	else
+		vma = NULL;
+	rcu_read_unlock();
+
+	return vma;
 }
 
 __bpf_kfunc void bpf_iter_task_vma_destroy(struct bpf_iter_task_vma *it)
@@ -873,7 +877,6 @@ __bpf_kfunc void bpf_iter_task_vma_destroy(struct bpf_iter_task_vma *it)
 	struct bpf_iter_task_vma_kern *kit = (void *)it;
 
 	if (kit->data) {
-		bpf_mmap_unlock_mm(kit->data->work, kit->data->mm);
 		put_task_struct(kit->data->task);
 		bpf_mem_free(&bpf_global_ma, kit->data);
 	}


### PR DESCRIPTION
The bpf_iter_task_vma iterator currently holds mmap_lock for the entire duration of iteration. This is problematic because BPF programs can call helpers like bpf_copy_from_user_task() while iterating, which internally calls __access_remote_vm() and attempts to acquire the same mmap_lock, causing a deadlock:

  lock(&mm->mmap_lock);        <- bpf_iter_task_vma_new
  lock(&mm->mmap_lock);        <- bpf_copy_from_user_task
  *** DEADLOCK ***

Remove the mmap_lock acquisition entirely and switch to address-based iteration that relies on:

1. RCU protection already provided by BPF program context
2. SLAB_TYPESAFE_BY_RCU flag on the VMA slab cache (vm_area_cachep), which guarantees VMA memory remains valid under RCU read lock
3. A vm_mm ownership check to detect VMAs that have been freed and reallocated to a different mm

The iterator now uses a saved address (next_addr) instead of maintaining a vma_iterator across calls. Each iteration initializes a fresh vma_iterator at the saved address and advances next_addr to vm_end of the found VMA. This approach is more robust as it doesn't rely on iterator state that could be invalidated by concurrent modifications.

This trades strict consistency for deadlock avoidance. VMA data may be slightly stale if the VMA is concurrently modified or freed, but this is acceptable for tracing use cases where the iterator is primarily used.