### PR TITLE
[RFC] bpf, arm64: Cache frequently accessed stack slots in register

### DIFF
--- a/arch/arm64/net/bpf_jit.h
+++ b/arch/arm64/net/bpf_jit.h
@@ -187,7 +187,8 @@
 /* Rn - imm12; set condition flags */
 #define A64_CMP_I(sf, Rn, imm12) A64_SUBS_I(sf, A64_ZR, Rn, imm12)
 /* Rd = Rn */
-#define A64_MOV(sf, Rd, Rn) A64_ADD_I(sf, Rd, Rn, 0)
+#define A64_MOV(sf, Rd, Rn) (((Rd) == A64_SP || (Rn) == A64_SP) ? A64_ADD_I(sf, Rd, Rn, 0) : \
+	 aarch64_insn_gen_move_reg(Rd, Rn, A64_VARIANT(sf)))
 
 /* Bitfield move */
 #define A64_BITFIELD(sf, Rd, Rn, immr, imms, type) \


### PR DESCRIPTION
Optimize hot FP-relative stack accesses by caching them in callee-saved registers. Track access frequency during JIT, select up to 8 hottest slots, and use a dynamic pool of r19-r24/r27/r28 depending on availability. Supports both 64-bit and 32-bit accesses with lane-based packing.