### PR TITLE
libbpf: Fix out-of-bound read in bpf_linker__add_buf()

### DIFF
--- a/tools/lib/bpf/linker.c
+++ b/tools/lib/bpf/linker.c
@@ -581,7 +581,7 @@ int bpf_linker__add_buf(struct bpf_linker *linker, void *buf, size_t buf_sz,
 
 	written = 0;
 	while (written < buf_sz) {
-		ret = write(fd, buf, buf_sz);
+		ret = write(fd, buf + written, buf_sz - written);
 		if (ret < 0) {
 			ret = -errno;
 			pr_warn("failed to write '%s': %s\n", filename, errstr(ret));


### PR DESCRIPTION
Fix a potential out-of-bound read in bpf_linker__add_buf() by advancing the buffer pointer and reducing the remaining buffer size passed to write() in each iteration. The bug is reported in [0].

[0]: https://github.com/libbpf/libbpf/issues/945

Fixes: 6d5e5e5d7ce1 ("libbpf: Extend linker API to support in-memory ELF files")