### PR TITLE
ftrace: Use hash argument for tmp_ops in update_ftrace_direct_mod

### DIFF
--- a/kernel/trace/ftrace.c
+++ b/kernel/trace/ftrace.c
@@ -6608,7 +6608,7 @@ int update_ftrace_direct_mod(struct ftrace_ops *ops, struct ftrace_hash *hash, b
 
 	/* Enable the tmp_ops to have the same functions as the direct ops */
 	ftrace_ops_init(&tmp_ops);
-	tmp_ops.func_hash = ops->func_hash;
+	tmp_ops.func_hash->filter_hash = hash;
 
 	err = register_ftrace_function_nolock(&tmp_ops);
 	if (err)


### PR DESCRIPTION
The modify logic registers temporary ftrace_ops object (tmp_ops) to trigger the slow path for all direct callers to be able to safely modify attached addresses.

At the moment we use ops->func_hash for tmp_ops filter, which represents all the systems attachments. It's faster to use just the passed hash filter, which contains only the modified sites is always a subset of the ops->func_hash.

Fixes: e93672f770d7 ("ftrace: Add update_ftrace_direct_mod function")