### PR TITLE
bpf: Drop redundant CONT_JMP alias

### DIFF
--- a/kernel/bpf/core.c
+++ b/kernel/bpf/core.c
@@ -1770,7 +1770,6 @@ static u64 ___bpf_prog_run(u64 *regs, const struct bpf_insn *insn)
 	u32 tail_call_cnt = 0;
 
 #define CONT	 ({ insn++; goto select_insn; })
-#define CONT_JMP ({ insn++; goto select_insn; })
 
 select_insn:
 	goto *jumptable[insn->code];
@@ -2089,25 +2088,25 @@ out:
 	JMP_##OPCODE##_X:					\
 		if ((SIGN##64) DST CMP_OP (SIGN##64) SRC) {	\
 			insn += insn->off;			\
-			CONT_JMP;				\
+			CONT;					\
 		}						\
 		CONT;						\
 	JMP32_##OPCODE##_X:					\
 		if ((SIGN##32) DST CMP_OP (SIGN##32) SRC) {	\
 			insn += insn->off;			\
-			CONT_JMP;				\
+			CONT;					\
 		}						\
 		CONT;						\
 	JMP_##OPCODE##_K:					\
 		if ((SIGN##64) DST CMP_OP (SIGN##64) IMM) {	\
 			insn += insn->off;			\
-			CONT_JMP;				\
+			CONT;					\
 		}						\
 		CONT;						\
 	JMP32_##OPCODE##_K:					\
 		if ((SIGN##32) DST CMP_OP (SIGN##32) IMM) {	\
 			insn += insn->off;			\
-			CONT_JMP;				\
+			CONT;					\
 		}						\
 		CONT;
 	COND_JMP(u, JEQ, ==)


### PR DESCRIPTION
The classic BPF interpreter used CONT_JMP on taken conditional branches and CONT on fall-through paths.

That naming split remained after the interpreter code moved from net/core/filter.c to kernel/bpf/core.c.

Still, both macros have long expanded to the same
`insn++; goto select_insn;` sequence. Replace the remaining CONT_JMP sites in COND_JMP() with CONT and drop the redundant alias.

No functional change intended.

Co-developed-by: Shenghao Yuan <shenghaoyuan0928@163.com>

Co-developed-by: Yazhou Tang <tangyazhou518@outlook.com>


(cherry picked from commit 2385e000d860d57087fb6e10b3cf0ae17ae76e4a)