### PR TITLE
bpf, arm64: Use nosync text patching to avoid IPIs

### DIFF
--- a/arch/arm64/include/asm/text-patching.h
+++ b/arch/arm64/include/asm/text-patching.h
@@ -8,7 +8,9 @@ int aarch64_insn_read(void *addr, u32 *insnp);
 int aarch64_insn_write(void *addr, u32 insn);
 
 int aarch64_insn_write_literal_u64(void *addr, u64 val);
+void *aarch64_insn_set_nosync(void *dst, u32 insn, size_t len);
 void *aarch64_insn_set(void *dst, u32 insn, size_t len);
+void *aarch64_insn_copy_nosync(void *dst, void *src, size_t len);
 void *aarch64_insn_copy(void *dst, void *src, size_t len);
 
 int aarch64_insn_patch_text_nosync(void *addr, u32 insn);

--- a/arch/arm64/kernel/patching.c
+++ b/arch/arm64/kernel/patching.c
@@ -104,7 +104,7 @@ noinstr int aarch64_insn_write_literal_u64(void *addr, u64 val)
 
 typedef void text_poke_f(void *dst, void *src, size_t patched, size_t len);
 
-static void *__text_poke(text_poke_f func, void *addr, void *src, size_t len)
+static void *__text_poke(text_poke_f func, void *addr, void *src, size_t len, bool sync)
 {
 	unsigned long flags;
 	size_t patched = 0;
@@ -127,7 +127,10 @@ static void *__text_poke(text_poke_f func, void *addr, void *src, size_t len)
 	}
 	raw_spin_unlock_irqrestore(&patch_lock, flags);
 
-	flush_icache_range((uintptr_t)addr, (uintptr_t)addr + len);
+	if (sync)
+		flush_icache_range((uintptr_t)addr, (uintptr_t)addr + len);
+	else
+		caches_clean_inval_pou((uintptr_t)addr, (uintptr_t)addr + len);
 
 	return addr;
 }
@@ -158,7 +161,16 @@ noinstr void *aarch64_insn_copy(void *dst, void *src, size_t len)
 	if ((uintptr_t)dst & 0x3)
 		return NULL;
 
-	return __text_poke(text_poke_memcpy, dst, src, len);
+	return __text_poke(text_poke_memcpy, dst, src, len, true);
+}
+
+noinstr void *aarch64_insn_copy_nosync(void *dst, void *src, size_t len)
+{
+	/* A64 instructions must be word aligned */
+	if ((uintptr_t)dst & 0x3)
+		return NULL;
+
+	return __text_poke(text_poke_memcpy, dst, src, len, false);
 }
 
 /**
@@ -174,7 +186,15 @@ noinstr void *aarch64_insn_set(void *dst, u32 insn, size_t len)
 	if ((uintptr_t)dst & 0x3)
 		return NULL;
 
-	return __text_poke(text_poke_memset, dst, &insn, len);
+	return __text_poke(text_poke_memset, dst, &insn, len, true);
+}
+
+noinstr void *aarch64_insn_set_nosync(void *dst, u32 insn, size_t len)
+{
+	if ((uintptr_t)dst & 0x3)
+		return NULL;
+
+	return __text_poke(text_poke_memset, dst, &insn, len, false);
 }
 
 int __kprobes aarch64_insn_patch_text_nosync(void *addr, u32 insn)

--- a/arch/arm64/net/bpf_jit_comp.c
+++ b/arch/arm64/net/bpf_jit_comp.c
@@ -271,7 +271,7 @@ static void jit_fill_hole(void *area, unsigned int size)
 
 int bpf_arch_text_invalidate(void *dst, size_t len)
 {
-	if (!aarch64_insn_set(dst, AARCH64_BREAK_FAULT, len))
+	if (!aarch64_insn_set_nosync(dst, AARCH64_BREAK_FAULT, len))
 		return -EINVAL;
 
 	return 0;
@@ -2231,7 +2231,7 @@ bool bpf_jit_supports_kfunc_call(void)
 
 void *bpf_arch_text_copy(void *dst, void *src, size_t len)
 {
-	if (!aarch64_insn_copy(dst, src, len))
+	if (!aarch64_insn_copy_nosync(dst, src, len))
 		return ERR_PTR(-EINVAL);
 	return dst;
 }


### PR DESCRIPTION
bpf, arm64: Use nosync text patching to avoid IPIs
Switch bpf_arch_text_copy() and bpf_arch_text_invalidate() to use
aarch64_insn_copy_nosync() and aarch64_insn_set_nosync() respectively,
eliminating the cross-CPU IPI (kick_all_cpus_sync()) on every BPF
program load and unload.

This is safe because the BPF subsystem already guarantees through
external synchronization that no CPU is executing code in the target
regions when these functions are called:

bpf_arch_text_copy() is called from:

  1. bpf_jit_binary_pack_finalize() - copies JIT'd code into an RO
     region that is not currently under execution. The prog pack
     allocator reuses VA slots from a large (2M) allocation, so a
     previous program may have executed from the same address. However,
     the previous occupant was freed through bpf_prog_put() which
     calls call_rcu() / call_rcu_tasks_trace() before reaching
     bpf_prog_pack_free(), ensuring an RCU grace period has elapsed.
     This means every CPU has passed through a quiescent state,
     flushing its pipeline, and bpf_arch_text_invalidate() has
     already invalidated the icache for that region. By the time
     the slot is reallocated, no CPU retains stale pipeline or
     icache entries from the old program.

  2. Trampoline installation - writes to an unused region (double-
     buffered in the dispatcher case), with synchronize_rcu() used
     separately to quiesce the old code path.

  3. Error cleanup path - writes the size field into ro_header for
     bpf_jit_binary_pack_free(), not executable code.

bpf_arch_text_invalidate() is called from bpf_prog_pack_free(), which
is reached through the following call chain:

  bpf_prog_put()
    -> __bpf_prog_put_noref(prog, true)
      -> call_rcu() / call_rcu_tasks_trace()
        -> __bpf_prog_put_rcu()
          -> bpf_prog_free()
            -> schedule_work(bpf_prog_free_deferred)
              -> bpf_jit_free()
                -> bpf_jit_binary_pack_free()
                  -> bpf_arch_text_invalidate()

The call_rcu() / call_rcu_tasks_trace() ensures an RCU grace period
has elapsed before the program is freed. This guarantees every CPU has
passed through a quiescent state, which on arm64 involves a context
switch whose exception return (ERET) is a context synchronization
event. This flushes the instruction pipeline on all CPUs, providing
the same guarantee as kick_all_cpus_sync() but without the cost.

The dcache clean and icache invalidation (broadcast via ISH) performed
by the nosync variants are sufficient for cache coherency. The RCU
grace period already guarantees pipeline synchronization on all CPUs.

The IPI overhead is significant on large systems as
kick_all_cpus_sync() interrupts every online CPU. This change
eliminates two rounds of IPIs per BPF program free+load cycle.

Signed-off-by: Puranjay Mohan <puranjay@kernel.org>