### PR TITLE
bpf: Fix BPF_PROG_ASSOC_STRUCT_OPS last field check

### DIFF
--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -6189,7 +6189,7 @@ static int prog_stream_read(union bpf_attr *attr)
 	return ret;
 }
 
-#define BPF_PROG_ASSOC_STRUCT_OPS_LAST_FIELD prog_assoc_struct_ops.prog_fd
+#define BPF_PROG_ASSOC_STRUCT_OPS_LAST_FIELD prog_assoc_struct_ops.flags
 
 static int prog_assoc_struct_ops(union bpf_attr *attr)
 {


### PR DESCRIPTION
When struct prog_assoc_struct_ops was added,
BPF_PROG_ASSOC_STRUCT_OPS_LAST_FIELD referenced prog_fd instead of the actual last field, flags.

Fixes: b5709f6d26d6 ("bpf: Support associating BPF program with struct_ops")