### PR TITLE
bpf: sk_storage: reserve inline storage in the socket

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -182,6 +182,7 @@ struct bpf_map_ops {
 				     void *callback_ctx, u64 flags);
 
 	u64 (*map_mem_usage)(const struct bpf_map *map);
+	int (*map_settle)(struct bpf_map *map);
 
 	/* BTF id of struct allocated by map_alloc */
 	int *map_btf_id;

--- a/include/linux/bpf_local_storage.h
+++ b/include/linux/bpf_local_storage.h
@@ -51,9 +51,11 @@ struct bpf_local_storage_map {
 	 * multiple buckets to improve contention.
 	 */
 	struct bpf_local_storage_map_bucket *buckets;
+	u32 reserve_off;
 	u32 bucket_log;
 	u16 elem_size;
 	u16 cache_idx;
+	u8 reserve_slot;
 };
 
 struct bpf_local_storage_data {
@@ -128,6 +130,31 @@ struct bpf_local_storage_cache {
 static struct bpf_local_storage_cache name = {			\
 	.idx_lock = __SPIN_LOCK_UNLOCKED(name.idx_lock),	\
 }
+
+#define MAX_BPF_SK_RESERVE_BYTES 1024
+#define MAX_BPF_LS_RESERVE_SLOTS (MAX_BPF_SK_RESERVE_BYTES / 8)
+
+struct bpf_ls_reserve_slot {
+	u16 off;
+	u16 size;
+	bool active;
+};
+
+struct bpf_ls_reserve {
+	spinlock_t lock; /* protects slots[], bump, nr_slots */
+	u16 limit;
+	u16 bump;
+	u8 nr_slots;
+	struct bpf_ls_reserve_slot slots[MAX_BPF_LS_RESERVE_SLOTS];
+};
+
+#define DEFINE_BPF_LS_RESERVE(name)					\
+static struct bpf_ls_reserve name = {					\
+	.lock = __SPIN_LOCK_UNLOCKED(name.lock),			\
+}
+
+int bpf_ls_reserve_alloc(struct bpf_local_storage_map *smap, struct bpf_ls_reserve *reserve);
+void bpf_ls_reserve_free(struct bpf_local_storage_map *smap, struct bpf_ls_reserve *reserve);
 
 /* Helper functions for bpf_local_storage */
 int bpf_local_storage_map_alloc_check(union bpf_attr *attr);

--- a/include/net/bpf_sk_storage.h
+++ b/include/net/bpf_sk_storage.h
@@ -28,6 +28,8 @@ struct bpf_sk_storage_diag;
 struct sk_buff;
 struct nlattr;
 
+extern u32 bpf_sk_reserve;
+
 #ifdef CONFIG_BPF_SYSCALL
 int bpf_sk_storage_clone(const struct sock *sk, struct sock *newsk);
 struct bpf_sk_storage_diag *

--- a/kernel/bpf/bpf_local_storage.c
+++ b/kernel/bpf/bpf_local_storage.c
@@ -699,6 +699,53 @@ static void bpf_local_storage_cache_idx_free(struct bpf_local_storage_cache *cac
 	spin_unlock(&cache->idx_lock);
 }
 
+int bpf_ls_reserve_alloc(struct bpf_local_storage_map *smap, struct bpf_ls_reserve *reserve)
+{
+	u32 needed = round_up(sizeof(u32) + smap->map.value_size, 8);
+	int i, err = -ENOSPC;
+
+	spin_lock(&reserve->lock);
+
+	for (i = 0; i < reserve->nr_slots; i++) {
+		struct bpf_ls_reserve_slot *slot = &reserve->slots[i];
+
+		if (slot->active || slot->size < needed)
+			continue;
+
+		slot->active = true;
+		smap->reserve_slot = i;
+		smap->reserve_off = reserve->limit - slot->off - sizeof(u32);
+		err = 0;
+		goto unlock;
+	}
+
+	if (reserve->nr_slots >= MAX_BPF_LS_RESERVE_SLOTS ||
+	    reserve->bump + needed > reserve->limit)
+		goto unlock;
+
+	i = reserve->nr_slots++;
+	reserve->slots[i].off = reserve->bump;
+	reserve->slots[i].size = needed;
+	reserve->slots[i].active = true;
+
+	smap->reserve_slot = i;
+	smap->reserve_off = reserve->limit - reserve->bump - sizeof(u32);
+	reserve->bump += needed;
+	err = 0;
+
+unlock:
+	spin_unlock(&reserve->lock);
+	return err;
+}
+
+void bpf_ls_reserve_free(struct bpf_local_storage_map *smap, struct bpf_ls_reserve *reserve)
+{
+	spin_lock(&reserve->lock);
+	if (smap->reserve_slot < reserve->nr_slots)
+		reserve->slots[smap->reserve_slot].active = false;
+	spin_unlock(&reserve->lock);
+}
+
 int bpf_local_storage_map_alloc_check(union bpf_attr *attr)
 {
 	if (attr->map_flags & ~BPF_LOCAL_STORAGE_CREATE_FLAG_MASK ||

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -1659,6 +1659,12 @@ static int map_create(union bpf_attr *attr, bpfptr_t uattr, struct bpf_common_at
 	if (err)
 		goto free_map_sec;
 
+	if (map->ops->map_settle) {
+		err = map->ops->map_settle(map);
+		if (err)
+			goto free_map_sec;
+	}
+
 	err = bpf_map_alloc_id(map);
 	if (err)
 		goto free_map_sec;

--- a/net/core/bpf_sk_storage.c
+++ b/net/core/bpf_sk_storage.c
@@ -46,6 +46,8 @@ static int __init set_bpf_sk_reserve(char *str)
 
 	bpf_sk_reserve = rounded;
 	sk_reserve.limit = rounded;
+	pr_info("bpf_sk_reserve=%u set\n", bpf_sk_reserve);
+
 	return 1;
 }
 __setup("bpf_sk_reserve=", set_bpf_sk_reserve);
@@ -100,8 +102,11 @@ static void bpf_sk_storage_map_free(struct bpf_map *map)
 {
 	struct bpf_local_storage_map *smap = (struct bpf_local_storage_map *)map;
 
-	if (smap->reserve_off)
+	if (smap->reserve_off) {
+		pr_info("bpf_sk_reserve: freeing map '%s' slot=%u off=%u\n", map->name,
+			 smap->reserve_slot, smap->reserve_off);
 		bpf_ls_reserve_free(smap, &sk_reserve);
+	}
 
 	bpf_local_storage_map_free(map, &sk_cache);
 }
@@ -127,6 +132,7 @@ static int bpf_sk_storage_map_alloc_check(union bpf_attr *attr)
 static int bpf_sk_storage_map_settle(struct bpf_map *map)
 {
 	struct bpf_local_storage_map *smap;
+	int err;
 
 	/*
 	 * BPF_F_NO_PREALLOC selects the normal hash-based path.  Its
@@ -143,7 +149,20 @@ static int bpf_sk_storage_map_settle(struct bpf_map *map)
 	if (!IS_ERR_OR_NULL(map->record))
 		return -EINVAL;
 
-	return bpf_ls_reserve_alloc(smap, &sk_reserve);
+	err = bpf_ls_reserve_alloc(smap, &sk_reserve);
+
+	if (err) {
+		pr_info_ratelimited("bpf_sk_reserve: map '%s' not reserved: %d (bump=%u/%u nr=%u)\n",
+				    map->name, err, sk_reserve.bump, sk_reserve.limit,
+				    sk_reserve.nr_slots);
+		return err;
+	}
+
+	pr_info("bpf_sk_reserve: map '%s' reserved off=%u slot=%u (bump=%u/%u nr=%u)\n", map->name,
+		smap->reserve_off, smap->reserve_slot, sk_reserve.bump, sk_reserve.limit,
+		sk_reserve.nr_slots);
+
+	return 0;
 }
 
 static inline u32 *sk_reserve_owner(struct sock *sk, struct bpf_local_storage_map *smap)

--- a/net/core/bpf_sk_storage.c
+++ b/net/core/bpf_sk_storage.c
@@ -15,6 +15,40 @@
 #include <uapi/linux/btf.h>
 #include <linux/rcupdate_trace.h>
 
+#define MAX_BPF_SK_RESERVE_BYTES 1024
+
+u32 bpf_sk_reserve;
+
+static int __init set_bpf_sk_reserve(char *str)
+{
+	u32 reserve_size, rounded;
+	int ret;
+
+	ret = kstrtouint(str, 0, &reserve_size);
+	if (ret)
+		return ret;
+
+	if (reserve_size > MAX_BPF_SK_RESERVE_BYTES) {
+		pr_warn("bpf_sk_reserve=%u limited to %u\n", reserve_size,
+			MAX_BPF_SK_RESERVE_BYTES);
+		reserve_size = MAX_BPF_SK_RESERVE_BYTES;
+	}
+
+	/*
+	 * The reserved area sits in front of struct sock, so sk lands at
+	 * slab_start + bpf_sk_reserve.  Round up to a cache line so this
+	 * offset is a cache-line multiple and struct sock keeps its own
+	 * cache-line alignment instead of being shifted across lines.
+	 */
+	rounded = round_up(reserve_size, SMP_CACHE_BYTES);
+	if (rounded != reserve_size)
+		pr_info("bpf_sk_reserve=%u rounded up to %u\n", reserve_size, rounded);
+
+	bpf_sk_reserve = rounded;
+	return 1;
+}
+__setup("bpf_sk_reserve=", set_bpf_sk_reserve);
+
 DEFINE_BPF_STORAGE_CACHE(sk_cache);
 
 static struct bpf_local_storage_data *

--- a/net/core/bpf_sk_storage.c
+++ b/net/core/bpf_sk_storage.c
@@ -15,7 +15,7 @@
 #include <uapi/linux/btf.h>
 #include <linux/rcupdate_trace.h>
 
-#define MAX_BPF_SK_RESERVE_BYTES 1024
+DEFINE_BPF_LS_RESERVE(sk_reserve);
 
 u32 bpf_sk_reserve;
 
@@ -45,6 +45,7 @@ static int __init set_bpf_sk_reserve(char *str)
 		pr_info("bpf_sk_reserve=%u rounded up to %u\n", reserve_size, rounded);
 
 	bpf_sk_reserve = rounded;
+	sk_reserve.limit = rounded;
 	return 1;
 }
 __setup("bpf_sk_reserve=", set_bpf_sk_reserve);
@@ -97,12 +98,62 @@ out:
 
 static void bpf_sk_storage_map_free(struct bpf_map *map)
 {
+	struct bpf_local_storage_map *smap = (struct bpf_local_storage_map *)map;
+
+	if (smap->reserve_off)
+		bpf_ls_reserve_free(smap, &sk_reserve);
+
 	bpf_local_storage_map_free(map, &sk_cache);
 }
 
 static struct bpf_map *bpf_sk_storage_map_alloc(union bpf_attr *attr)
 {
 	return bpf_local_storage_map_alloc(attr, &sk_cache);
+}
+
+static int bpf_sk_storage_map_alloc_check(union bpf_attr *attr)
+{
+	if (attr->map_flags & ~(BPF_F_NO_PREALLOC | BPF_F_CLONE) || attr->max_entries ||
+	    attr->key_size != sizeof(int) || !attr->value_size || !attr->btf_key_type_id ||
+	    !attr->btf_value_type_id)
+		return -EINVAL;
+
+	if (attr->value_size > BPF_LOCAL_STORAGE_MAX_VALUE_SIZE)
+		return -E2BIG;
+
+	return 0;
+}
+
+static int bpf_sk_storage_map_settle(struct bpf_map *map)
+{
+	struct bpf_local_storage_map *smap;
+
+	/*
+	 * BPF_F_NO_PREALLOC selects the normal hash-based path.  Its
+	 * absence opts into reserved inline storage, which requires
+	 * bpf_sk_reserve to be configured; if it is not (or the pool is
+	 * full), bpf_ls_reserve_alloc() returns -ENOSPC and map creation
+	 * fails rather than silently downgrading to the hash path.
+	 */
+	if (map->map_flags & BPF_F_NO_PREALLOC)
+		return 0;
+
+	smap = (struct bpf_local_storage_map *)map;
+
+	if (!IS_ERR_OR_NULL(map->record))
+		return -EINVAL;
+
+	return bpf_ls_reserve_alloc(smap, &sk_reserve);
+}
+
+static inline u32 *sk_reserve_owner(struct sock *sk, struct bpf_local_storage_map *smap)
+{
+	return (u32 *)((void *)sk - smap->reserve_off) - 1;
+}
+
+static inline void *sk_reserve_data(struct sock *sk, struct bpf_local_storage_map *smap)
+{
+	return (void *)sk - smap->reserve_off;
 }
 
 static int notsupp_get_next_key(struct bpf_map *map, void *key,
@@ -113,54 +164,96 @@ static int notsupp_get_next_key(struct bpf_map *map, void *key,
 
 static void *bpf_fd_sk_storage_lookup_elem(struct bpf_map *map, void *key)
 {
+	struct bpf_local_storage_map *smap;
 	struct bpf_local_storage_data *sdata;
 	struct socket *sock;
 	int fd, err;
 
 	fd = *(int *)key;
 	sock = sockfd_lookup(fd, &err);
-	if (sock) {
-		sdata = bpf_sk_storage_lookup(sock->sk, map, true);
+	if (!sock)
+		return ERR_PTR(err);
+
+	smap = (struct bpf_local_storage_map *)map;
+	if (smap->reserve_off) {
+		u32 *owner = sk_reserve_owner(sock->sk, smap);
+		void *data;
+
+		data = (*owner == map->id) ?
+			sk_reserve_data(sock->sk, smap) : NULL;
 		sockfd_put(sock);
-		return sdata ? sdata->data : NULL;
+		return data;
 	}
 
-	return ERR_PTR(err);
+	sdata = bpf_sk_storage_lookup(sock->sk, map, true);
+	sockfd_put(sock);
+	return sdata ? sdata->data : NULL;
 }
 
 static long bpf_fd_sk_storage_update_elem(struct bpf_map *map, void *key,
 					  void *value, u64 map_flags)
 {
+	struct bpf_local_storage_map *smap;
 	struct bpf_local_storage_data *sdata;
 	struct socket *sock;
 	int fd, err;
 
 	fd = *(int *)key;
 	sock = sockfd_lookup(fd, &err);
-	if (sock) {
-		sdata = bpf_local_storage_update(
-			sock->sk, (struct bpf_local_storage_map *)map, value,
-			map_flags, false);
+	if (!sock)
+		return err;
+
+	smap = (struct bpf_local_storage_map *)map;
+	if (smap->reserve_off) {
+		u32 *owner = sk_reserve_owner(sock->sk, smap);
+		bool exists = (*owner == map->id);
+
+		if ((map_flags & BPF_NOEXIST) && exists) {
+			err = -EEXIST;
+		} else if ((map_flags & BPF_EXIST) && !exists) {
+			err = -ENOENT;
+		} else {
+			copy_map_value(map, sk_reserve_data(sock->sk, smap), value);
+			WRITE_ONCE(*owner, map->id);
+			err = 0;
+		}
 		sockfd_put(sock);
-		return PTR_ERR_OR_ZERO(sdata);
+		return err;
 	}
 
-	return err;
+	sdata = bpf_local_storage_update(sock->sk, smap, value, map_flags, false);
+	sockfd_put(sock);
+	return PTR_ERR_OR_ZERO(sdata);
 }
 
 static long bpf_fd_sk_storage_delete_elem(struct bpf_map *map, void *key)
 {
+	struct bpf_local_storage_map *smap;
 	struct socket *sock;
 	int fd, err;
 
 	fd = *(int *)key;
 	sock = sockfd_lookup(fd, &err);
-	if (sock) {
-		err = bpf_sk_storage_del(sock->sk, map);
+	if (!sock)
+		return err;
+
+	smap = (struct bpf_local_storage_map *)map;
+	if (smap->reserve_off) {
+		u32 *owner = sk_reserve_owner(sock->sk, smap);
+
+		if (*owner != map->id) {
+			err = -ENOENT;
+		} else {
+			memset(sk_reserve_data(sock->sk, smap), 0, map->value_size);
+			WRITE_ONCE(*owner, 0);
+			err = 0;
+		}
 		sockfd_put(sock);
 		return err;
 	}
 
+	err = bpf_sk_storage_del(sock->sk, map);
+	sockfd_put(sock);
 	return err;
 }
 
@@ -264,11 +357,29 @@ out:
 BPF_CALL_4(bpf_sk_storage_get, struct bpf_map *, map, struct sock *, sk,
 	   void *, value, u64, flags)
 {
+	struct bpf_local_storage_map *smap;
 	struct bpf_local_storage_data *sdata;
 
 	WARN_ON_ONCE(!bpf_rcu_lock_held());
 	if (!sk || !sk_fullsock(sk) || flags > BPF_SK_STORAGE_GET_F_CREATE)
 		return (unsigned long)NULL;
+
+	smap = (struct bpf_local_storage_map *)map;
+	if (smap->reserve_off) {
+		u32 *owner = sk_reserve_owner(sk, smap);
+		void *data = sk_reserve_data(sk, smap);
+
+		if (*owner != map->id) {
+			if (!(flags & BPF_LOCAL_STORAGE_GET_F_CREATE))
+				return (unsigned long)NULL;
+			if (value)
+				copy_map_value(map, data, value);
+			else
+				memset(data, 0, map->value_size);
+			WRITE_ONCE(*owner, map->id);
+		}
+		return (unsigned long)data;
+	}
 
 	sdata = bpf_sk_storage_lookup(sk, map, true);
 	if (sdata)
@@ -297,9 +408,22 @@ BPF_CALL_4(bpf_sk_storage_get, struct bpf_map *, map, struct sock *, sk,
 
 BPF_CALL_2(bpf_sk_storage_delete, struct bpf_map *, map, struct sock *, sk)
 {
+	struct bpf_local_storage_map *smap;
+
 	WARN_ON_ONCE(!bpf_rcu_lock_held());
 	if (!sk || !sk_fullsock(sk))
 		return -EINVAL;
+
+	smap = (struct bpf_local_storage_map *)map;
+	if (smap->reserve_off) {
+		u32 *owner = sk_reserve_owner(sk, smap);
+
+		if (*owner != map->id)
+			return -ENOENT;
+		memset(sk_reserve_data(sk, smap), 0, map->value_size);
+		WRITE_ONCE(*owner, 0);
+		return 0;
+	}
 
 	if (refcount_inc_not_zero(&sk->sk_refcnt)) {
 		int err;
@@ -347,7 +471,7 @@ bpf_sk_storage_ptr(void *owner)
 
 const struct bpf_map_ops sk_storage_map_ops = {
 	.map_meta_equal = bpf_map_meta_equal,
-	.map_alloc_check = bpf_local_storage_map_alloc_check,
+	.map_alloc_check = bpf_sk_storage_map_alloc_check,
 	.map_alloc = bpf_sk_storage_map_alloc,
 	.map_free = bpf_sk_storage_map_free,
 	.map_get_next_key = notsupp_get_next_key,
@@ -360,6 +484,7 @@ const struct bpf_map_ops sk_storage_map_ops = {
 	.map_local_storage_uncharge = bpf_sk_storage_uncharge,
 	.map_owner_storage_ptr = bpf_sk_storage_ptr,
 	.map_mem_usage = bpf_local_storage_map_mem_usage,
+	.map_settle = bpf_sk_storage_map_settle,
 };
 
 const struct bpf_func_proto bpf_sk_storage_get_proto = {
@@ -897,6 +1022,9 @@ static int bpf_iter_attach_map(struct bpf_prog *prog,
 		return PTR_ERR(map);
 
 	if (map->map_type != BPF_MAP_TYPE_SK_STORAGE)
+		goto put_map;
+
+	if (((struct bpf_local_storage_map *)map)->reserve_off)
 		goto put_map;
 
 	if (prog->aux->max_rdwr_access > map->value_size) {

--- a/net/core/sock.c
+++ b/net/core/sock.c
@@ -2202,6 +2202,44 @@ static inline void sock_lock_init(struct sock *sk)
 			af_family_keys + sk->sk_family);
 }
 
+#ifdef CONFIG_BPF_SYSCALL
+#include <net/bpf_sk_storage.h>
+
+static inline int sk_reserved_size(int obj_size)
+{
+	return obj_size + bpf_sk_reserve;
+}
+
+static inline struct sock *sk_from_reserve(void *p)
+{
+	return (struct sock *)(p + bpf_sk_reserve);
+}
+
+static inline void *sk_to_reserve(struct sock *sk)
+{
+	return (void *)sk - bpf_sk_reserve;
+}
+
+static inline void sk_reserve_init(struct sock *sk)
+{
+	if (unlikely(bpf_sk_reserve))
+		memset(sk_to_reserve(sk), 0, bpf_sk_reserve);
+}
+
+static inline void sk_reserve_clone(struct sock *newsk, const struct sock *oldsk)
+{
+	if (unlikely(bpf_sk_reserve))
+		memcpy(sk_to_reserve(newsk),
+		       (void *)oldsk - bpf_sk_reserve, bpf_sk_reserve);
+}
+#else
+static inline int sk_reserved_size(int obj_size) { return obj_size; }
+static inline struct sock *sk_from_reserve(void *p) { return (struct sock *)p; }
+static inline void *sk_to_reserve(struct sock *sk) { return (void *)sk; }
+static inline void sk_reserve_init(struct sock *sk) {}
+static inline void sk_reserve_clone(struct sock *n, const struct sock *o) {}
+#endif
+
 /*
  * Copy all fields from osk to nsk but nsk->sk_refcnt must not change yet,
  * even temporarily, because of RCU lookups. sk_node should also be left as is.
@@ -2246,10 +2284,14 @@ static struct sock *sk_prot_alloc(struct proto *prot, gfp_t priority,
 		sk = kmem_cache_alloc(slab, priority & ~__GFP_ZERO);
 		if (!sk)
 			return sk;
+		sk = sk_from_reserve(sk);
 		if (want_init_on_alloc(priority))
 			sk_prot_clear_nulls(sk, prot->obj_size);
-	} else
-		sk = kmalloc(prot->obj_size, priority);
+	} else {
+		sk = kmalloc(sk_reserved_size(prot->obj_size), priority);
+		if (sk)
+			sk = sk_from_reserve(sk);
+	}
 
 	if (sk != NULL) {
 		if (security_sk_alloc(sk, family, priority))
@@ -2257,6 +2299,8 @@ static struct sock *sk_prot_alloc(struct proto *prot, gfp_t priority,
 
 		if (!try_module_get(prot->owner))
 			goto out_free_sec;
+
+		sk_reserve_init(sk);
 	}
 
 	return sk;
@@ -2265,9 +2309,9 @@ out_free_sec:
 	security_sk_free(sk);
 out_free:
 	if (slab != NULL)
-		kmem_cache_free(slab, sk);
+		kmem_cache_free(slab, sk_to_reserve(sk));
 	else
-		kfree(sk);
+		kfree(sk_to_reserve(sk));
 	return NULL;
 }
 
@@ -2286,9 +2330,9 @@ static void sk_prot_free(struct proto *prot, struct sock *sk)
 	sk_owner_put(sk);
 
 	if (slab != NULL)
-		kmem_cache_free(slab, sk);
+		kmem_cache_free(slab, sk_to_reserve(sk));
 	else
-		kfree(sk);
+		kfree(sk_to_reserve(sk));
 	module_put(owner);
 }
 
@@ -2490,6 +2534,7 @@ struct sock *sk_clone(const struct sock *sk, const gfp_t priority,
 		goto out;
 
 	sock_copy(newsk, sk);
+	sk_reserve_clone(newsk, sk);
 
 	newsk->sk_prot_creator = prot;
 
@@ -4258,10 +4303,19 @@ int proto_register(struct proto *prot, int alloc_slab)
 			.use_freeptr_offset = !!prot->freeptr_offset,
 		};
 
-		prot->slab = kmem_cache_create(prot->name, prot->obj_size,
-					&args,
-					SLAB_HWCACHE_ALIGN | SLAB_ACCOUNT |
-					prot->slab_flags);
+#ifdef CONFIG_BPF_SYSCALL
+		if (bpf_sk_reserve) {
+			if (prot->usersize)
+				args.useroffset += bpf_sk_reserve;
+			if (prot->freeptr_offset)
+				args.freeptr_offset += bpf_sk_reserve;
+		}
+#endif
+		prot->slab = kmem_cache_create(prot->name,
+					       sk_reserved_size(prot->obj_size),
+					       &args,
+					       SLAB_HWCACHE_ALIGN | SLAB_ACCOUNT |
+					       prot->slab_flags);
 		if (prot->slab == NULL) {
 			pr_crit("%s: Can't create sock SLAB cache!\n",
 				prot->name);

--- a/tools/testing/selftests/bpf/Makefile
+++ b/tools/testing/selftests/bpf/Makefile
@@ -976,6 +976,7 @@ $(OUTPUT)/bench_bpf_hashmap_lookup.o: $(OUTPUT)/bpf_hashmap_lookup.skel.h
 $(OUTPUT)/bench_htab_mem.o: $(OUTPUT)/htab_mem_bench.skel.h
 $(OUTPUT)/bench_bpf_crypto.o: $(OUTPUT)/crypto_bench.skel.h
 $(OUTPUT)/bench_sockmap.o: $(OUTPUT)/bench_sockmap_prog.skel.h
+$(OUTPUT)/bench_sk_storage.o: $(OUTPUT)/sk_storage_bench.skel.h
 $(OUTPUT)/bench_lpm_trie_map.o: $(OUTPUT)/lpm_trie_bench.skel.h $(OUTPUT)/lpm_trie_map.skel.h
 $(OUTPUT)/bench_bpf_nop.o: $(OUTPUT)/bpf_nop_bench.skel.h bench_bpf_timing.h
 $(OUTPUT)/bench_xdp_lb.o: $(OUTPUT)/xdp_lb_bench.skel.h bench_bpf_timing.h
@@ -1002,6 +1003,7 @@ $(OUTPUT)/bench: $(OUTPUT)/bench.o \
 		 $(OUTPUT)/bench_bpf_crypto.o \
 		 $(OUTPUT)/bench_sockmap.o \
 		 $(OUTPUT)/bench_lpm_trie_map.o \
+		 $(OUTPUT)/bench_sk_storage.o \
 		 $(OUTPUT)/bench_bpf_timing.o \
 		 $(OUTPUT)/bench_bpf_nop.o \
 		 $(OUTPUT)/bench_xdp_lb.o \

--- a/tools/testing/selftests/bpf/bench.c
+++ b/tools/testing/selftests/bpf/bench.c
@@ -287,6 +287,7 @@ extern struct argp bench_crypto_argp;
 extern struct argp bench_sockmap_argp;
 extern struct argp bench_lpm_trie_map_argp;
 extern struct argp bench_xdp_lb_argp;
+extern struct argp bench_sk_storage_argp;
 
 static const struct argp_child bench_parsers[] = {
 	{ &bench_ringbufs_argp, 0, "Ring buffers benchmark", 0 },
@@ -304,6 +305,7 @@ static const struct argp_child bench_parsers[] = {
 	{ &bench_sockmap_argp, 0, "bpf sockmap benchmark", 0 },
 	{ &bench_lpm_trie_map_argp, 0, "LPM trie map benchmark", 0 },
 	{ &bench_xdp_lb_argp, 0, "XDP load-balancer benchmark", 0 },
+	{ &bench_sk_storage_argp, 0, "sk_storage benchmark", 0 },
 	{},
 };
 
@@ -580,6 +582,7 @@ extern const struct bench bench_lpm_trie_insert;
 extern const struct bench bench_lpm_trie_update;
 extern const struct bench bench_lpm_trie_delete;
 extern const struct bench bench_lpm_trie_free;
+extern const struct bench bench_sk_storage_get;
 extern const struct bench bench_bpf_nop;
 extern const struct bench bench_xdp_lb;
 
@@ -663,6 +666,7 @@ static const struct bench *benchs[] = {
 	&bench_lpm_trie_update,
 	&bench_lpm_trie_delete,
 	&bench_lpm_trie_free,
+	&bench_sk_storage_get,
 	&bench_bpf_nop,
 	&bench_xdp_lb,
 };

--- a/tools/testing/selftests/bpf/benchs/bench_sk_storage.c
+++ b/tools/testing/selftests/bpf/benchs/bench_sk_storage.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 Meta Platforms, Inc. and affiliates. */
+
+#include <argp.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "sk_storage_bench.skel.h"
+#include "bench.h"
+
+/*
+ * sk_storage_get benchmark.
+ *
+ * Creates nr_socks listening sockets (so they live in the TCP hashtable)
+ * and drives a bpf_iter/tcp pass over them.  Each read() of the iterator
+ * visits every socket once, calling bpf_sk_storage_get() on a different
+ * (cold) socket each time.  The syscall cost is amortized over all
+ * sockets, so the measured rate reflects the storage-access cost rather
+ * than getsockopt() overhead.  With a large socket count the working set
+ * exceeds the CPU caches, which is where reserved inline storage avoids
+ * the pointer chase of the hash-based path.
+ */
+
+static struct {
+	__u32 nr_socks;
+} args = {
+	.nr_socks = 100000,
+};
+
+enum {
+	ARG_NR_SOCKS = 8000,
+};
+
+static const struct argp_option opts[] = {
+	{ "nr-socks", ARG_NR_SOCKS, "NR_SOCKS", 0,
+	  "Number of listening sockets to iterate (default 100000)" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	long ret;
+
+	switch (key) {
+	case ARG_NR_SOCKS:
+		ret = strtol(arg, NULL, 10);
+		if (ret < 1 || ret > INT_MAX) {
+			fprintf(stderr, "invalid nr-socks\n");
+			argp_usage(state);
+		}
+		args.nr_socks = ret;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+
+	return 0;
+}
+
+const struct argp bench_sk_storage_argp = {
+	.options = opts,
+	.parser = parse_arg,
+};
+
+static struct {
+	struct sk_storage_bench *skel;
+	struct bpf_link *link;
+	int *sock_fds;
+	__u32 nr_socks;
+} ctx;
+
+static void sk_storage_validate(void)
+{
+	if (env.producer_cnt != 1) {
+		fprintf(stderr, "benchmark needs single producer\n");
+		exit(1);
+	}
+	if (env.consumer_cnt != 0) {
+		fprintf(stderr, "benchmark does not support consumers\n");
+		exit(1);
+	}
+}
+
+/* One bpf_iter/tcp pass over all sockets in the netns. */
+static void iter_pass(void)
+{
+	char buf[64];
+	int iter_fd;
+	ssize_t n;
+
+	iter_fd = bpf_iter_create(bpf_link__fd(ctx.link));
+	if (iter_fd < 0) {
+		fprintf(stderr, "Error creating iter fd\n");
+		exit(1);
+	}
+
+	while ((n = read(iter_fd, buf, sizeof(buf))) > 0)
+		;
+
+	close(iter_fd);
+}
+
+static void sk_storage_setup(void)
+{
+	struct rlimit rlim;
+	int i;
+
+	setup_libbpf();
+
+	rlim.rlim_cur = rlim.rlim_max = args.nr_socks + 1024;
+	if (setrlimit(RLIMIT_NOFILE, &rlim)) {
+		fprintf(stderr, "Error raising RLIMIT_NOFILE for %u sockets\n",
+			args.nr_socks);
+		exit(1);
+	}
+
+	ctx.skel = sk_storage_bench__open_and_load();
+	if (!ctx.skel) {
+		fprintf(stderr, "Error opening/loading skeleton\n");
+		exit(1);
+	}
+
+	ctx.nr_socks = args.nr_socks;
+	ctx.sock_fds = calloc(ctx.nr_socks, sizeof(*ctx.sock_fds));
+	if (!ctx.sock_fds) {
+		fprintf(stderr, "Error allocating socket array\n");
+		exit(1);
+	}
+
+	/*
+	 * Create listening sockets so each lives in the TCP listen
+	 * hashtable and is visited by iter/tcp.  Spread (addr, port)
+	 * across 127.0.0.0/8 to avoid ephemeral port exhaustion.
+	 */
+	for (i = 0; i < ctx.nr_socks; i++) {
+		struct sockaddr_in addr = {
+			.sin_family = AF_INET,
+			.sin_port = htons(1024 + (i % 60000)),
+		};
+		int fd;
+
+		addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK + i / 60000);
+
+		fd = socket(AF_INET, SOCK_STREAM, 0);
+		if (fd < 0) {
+			fprintf(stderr, "Error creating socket %d\n", i);
+			exit(1);
+		}
+		if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) ||
+		    listen(fd, 1)) {
+			fprintf(stderr, "Error binding/listening socket %d\n", i);
+			exit(1);
+		}
+		ctx.sock_fds[i] = fd;
+	}
+
+	ctx.link = bpf_program__attach_iter(ctx.skel->progs.iter_sk_storage_get,
+					    NULL);
+	if (!ctx.link) {
+		fprintf(stderr, "Error attaching iter program\n");
+		exit(1);
+	}
+
+	/* Warm up: create storage so the measured loop is get-existing. */
+	iter_pass();
+}
+
+static void sk_storage_measure(struct bench_res *res)
+{
+	res->hits = atomic_swap(&ctx.skel->bss->hits, 0);
+}
+
+static void *sk_storage_producer(void *input)
+{
+	while (true)
+		iter_pass();
+
+	return NULL;
+}
+
+const struct bench bench_sk_storage_get = {
+	.name = "sk-storage-get",
+	.argp = &bench_sk_storage_argp,
+	.validate = sk_storage_validate,
+	.setup = sk_storage_setup,
+	.producer_thread = sk_storage_producer,
+	.measure = sk_storage_measure,
+	.report_progress = ops_report_progress,
+	.report_final = ops_report_final,
+};

--- a/tools/testing/selftests/bpf/prog_tests/sk_ls_reserve.c
+++ b/tools/testing/selftests/bpf/prog_tests/sk_ls_reserve.c
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/* Copyright (c) 2025 Meta Platforms, Inc. and affiliates. */
+
+#include <test_progs.h>
+#include <bpf/btf.h>
+#include "sk_ls_reserve.skel.h"
+
+static int cgroup_fd;
+
+/*
+ * Reserved storage is only active when the kernel was booted with
+ * bpf_sk_reserve=N.  An sk_storage map created without BPF_F_NO_PREALLOC
+ * opts into reserved storage and fails with -ENOSPC when no reserve is
+ * configured.  Probe with such a map to decide whether to run.
+ */
+static bool reserve_enabled(void)
+{
+	LIBBPF_OPTS(bpf_map_create_opts, opts);
+	struct btf *btf;
+	int key_tid, val_tid, fd;
+
+	btf = btf__new_empty();
+	if (!ASSERT_OK_PTR(btf, "btf__new_empty"))
+		return false;
+
+	key_tid = btf__add_int(btf, "int", 4, BTF_INT_SIGNED);
+	val_tid = btf__add_int(btf, "value", 4, 0);
+	if (btf__load_into_kernel(btf)) {
+		btf__free(btf);
+		return false;
+	}
+
+	opts.btf_fd = btf__fd(btf);
+	opts.btf_key_type_id = key_tid;
+	opts.btf_value_type_id = val_tid;
+	/* No BPF_F_NO_PREALLOC: requests reserved storage. */
+	fd = bpf_map_create(BPF_MAP_TYPE_SK_STORAGE, "rsv_probe",
+			    sizeof(int), 4, 0, &opts);
+	btf__free(btf);
+	if (fd < 0)
+		return false;
+
+	close(fd);
+	return true;
+}
+
+static void test_get_create_delete(void)
+{
+	struct sk_ls_reserve *skel;
+	int fd = -1, err;
+	socklen_t len;
+	int val;
+
+	skel = sk_ls_reserve__open_and_load();
+	if (!ASSERT_OK_PTR(skel, "open_and_load"))
+		return;
+
+	skel->links.get_create =
+		bpf_program__attach_cgroup(skel->progs.get_create, cgroup_fd);
+	if (!ASSERT_OK_PTR(skel->links.get_create, "attach"))
+		goto done;
+
+	fd = socket(AF_INET6, SOCK_STREAM, 0);
+	if (!ASSERT_OK_FD(fd, "socket"))
+		goto done;
+
+	len = sizeof(val);
+
+	skel->bss->test_op = 0;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "getsockopt_create");
+	ASSERT_EQ(skel->bss->result, 1, "create_ok");
+
+	skel->bss->test_op = 1;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "getsockopt_get");
+	ASSERT_EQ(skel->bss->result, 1, "get_ok");
+	ASSERT_EQ(skel->bss->val_a, 2, "val_a_after_two_gets");
+
+	skel->bss->test_op = 2;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "getsockopt_delete");
+	ASSERT_EQ(skel->bss->delete_result, 0, "delete_ok");
+
+	skel->bss->test_op = 1;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "getsockopt_get_after_delete");
+	ASSERT_EQ(skel->bss->result, 0, "get_after_delete_null");
+
+done:
+	if (fd != -1)
+		close(fd);
+	sk_ls_reserve__destroy(skel);
+}
+
+static void test_multiple_maps(void)
+{
+	struct sk_ls_reserve *skel;
+	int fd = -1, err;
+	socklen_t len;
+	int val;
+
+	skel = sk_ls_reserve__open_and_load();
+	if (!ASSERT_OK_PTR(skel, "open_and_load"))
+		return;
+
+	skel->links.get_create =
+		bpf_program__attach_cgroup(skel->progs.get_create, cgroup_fd);
+	if (!ASSERT_OK_PTR(skel->links.get_create, "attach"))
+		goto done;
+
+	fd = socket(AF_INET6, SOCK_STREAM, 0);
+	if (!ASSERT_OK_FD(fd, "socket"))
+		goto done;
+
+	len = sizeof(val);
+
+	skel->bss->test_op = 3;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "create_both");
+	ASSERT_EQ(skel->bss->result, 1, "map1_create_ok");
+	ASSERT_EQ(skel->bss->result2, 1, "map2_create_ok");
+	ASSERT_EQ(skel->bss->val_a, 1, "map1_val_a");
+	ASSERT_EQ(skel->bss->val2_a, 10, "map2_val_a");
+
+	skel->bss->test_op = 4;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "get_both");
+	ASSERT_EQ(skel->bss->result, 1, "map1_get_ok");
+	ASSERT_EQ(skel->bss->result2, 1, "map2_get_ok");
+
+	skel->bss->test_op = 5;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "delete_map2");
+	ASSERT_EQ(skel->bss->delete_result, 0, "map2_delete_ok");
+
+	skel->bss->test_op = 4;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "get_after_partial_delete");
+	ASSERT_EQ(skel->bss->result, 1, "map1_still_exists");
+	ASSERT_EQ(skel->bss->result2, 0, "map2_gone");
+
+done:
+	if (fd != -1)
+		close(fd);
+	sk_ls_reserve__destroy(skel);
+}
+
+static void test_create_with_value(void)
+{
+	struct sk_ls_reserve *skel;
+	int fd = -1, err;
+	socklen_t len;
+	int val;
+
+	skel = sk_ls_reserve__open_and_load();
+	if (!ASSERT_OK_PTR(skel, "open_and_load"))
+		return;
+
+	skel->links.get_create =
+		bpf_program__attach_cgroup(skel->progs.get_create, cgroup_fd);
+	if (!ASSERT_OK_PTR(skel->links.get_create, "attach"))
+		goto done;
+
+	fd = socket(AF_INET6, SOCK_STREAM, 0);
+	if (!ASSERT_OK_FD(fd, "socket"))
+		goto done;
+
+	len = sizeof(val);
+
+	skel->bss->test_op = 6;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "create_with_val");
+	ASSERT_EQ(skel->bss->result, 1, "create_val_ok");
+	ASSERT_EQ(skel->bss->val_a, 100, "init_val_a");
+
+	skel->bss->test_op = 7;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "create_again");
+	ASSERT_EQ(skel->bss->result, 1, "create_again_ok");
+	ASSERT_EQ(skel->bss->val_a, 101, "val_not_reset");
+
+done:
+	if (fd != -1)
+		close(fd);
+	sk_ls_reserve__destroy(skel);
+}
+
+static void test_delete_nonexistent(void)
+{
+	struct sk_ls_reserve *skel;
+	int fd = -1, err;
+	socklen_t len;
+	int val;
+
+	skel = sk_ls_reserve__open_and_load();
+	if (!ASSERT_OK_PTR(skel, "open_and_load"))
+		return;
+
+	skel->links.get_create =
+		bpf_program__attach_cgroup(skel->progs.get_create, cgroup_fd);
+	if (!ASSERT_OK_PTR(skel->links.get_create, "attach"))
+		goto done;
+
+	fd = socket(AF_INET6, SOCK_STREAM, 0);
+	if (!ASSERT_OK_FD(fd, "socket"))
+		goto done;
+
+	len = sizeof(val);
+
+	skel->bss->test_op = 8;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "delete_nonexist");
+	ASSERT_EQ(skel->bss->delete_result, -ENOENT, "enoent");
+
+done:
+	if (fd != -1)
+		close(fd);
+	sk_ls_reserve__destroy(skel);
+}
+
+static void test_multiple_sockets(void)
+{
+	struct sk_ls_reserve *skel;
+	int fd1 = -1, fd2 = -1, err;
+	socklen_t len;
+	int val;
+
+	skel = sk_ls_reserve__open_and_load();
+	if (!ASSERT_OK_PTR(skel, "open_and_load"))
+		return;
+
+	skel->links.get_create =
+		bpf_program__attach_cgroup(skel->progs.get_create, cgroup_fd);
+	if (!ASSERT_OK_PTR(skel->links.get_create, "attach"))
+		goto done;
+
+	fd1 = socket(AF_INET6, SOCK_STREAM, 0);
+	fd2 = socket(AF_INET6, SOCK_STREAM, 0);
+	if (!ASSERT_OK_FD(fd1, "socket1") || !ASSERT_OK_FD(fd2, "socket2"))
+		goto done;
+
+	len = sizeof(val);
+
+	skel->bss->test_op = 0;
+	err = getsockopt(fd1, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "create_sock1");
+
+	skel->bss->test_op = 0;
+	err = getsockopt(fd2, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "create_sock2");
+
+	skel->bss->test_op = 1;
+	err = getsockopt(fd1, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "get_sock1");
+	ASSERT_EQ(skel->bss->val_a, 2, "sock1_val_a");
+
+	skel->bss->test_op = 1;
+	err = getsockopt(fd2, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "get_sock2");
+	ASSERT_EQ(skel->bss->val_a, 2, "sock2_val_a");
+
+	skel->bss->test_op = 2;
+	err = getsockopt(fd1, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "delete_sock1");
+
+	skel->bss->test_op = 1;
+	err = getsockopt(fd1, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "get_sock1_deleted");
+	ASSERT_EQ(skel->bss->result, 0, "sock1_null");
+
+	skel->bss->test_op = 1;
+	err = getsockopt(fd2, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "get_sock2_unaffected");
+	ASSERT_EQ(skel->bss->result, 1, "sock2_ok");
+
+done:
+	if (fd1 != -1)
+		close(fd1);
+	if (fd2 != -1)
+		close(fd2);
+	sk_ls_reserve__destroy(skel);
+}
+
+static void test_recreate_after_delete(void)
+{
+	struct sk_ls_reserve *skel;
+	int fd = -1, err;
+	socklen_t len;
+	int val;
+
+	skel = sk_ls_reserve__open_and_load();
+	if (!ASSERT_OK_PTR(skel, "open_and_load"))
+		return;
+
+	skel->links.get_create =
+		bpf_program__attach_cgroup(skel->progs.get_create, cgroup_fd);
+	if (!ASSERT_OK_PTR(skel->links.get_create, "attach"))
+		goto done;
+
+	fd = socket(AF_INET6, SOCK_STREAM, 0);
+	if (!ASSERT_OK_FD(fd, "socket"))
+		goto done;
+
+	len = sizeof(val);
+
+	skel->bss->test_op = 0;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "create");
+
+	skel->bss->test_op = 2;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "delete");
+	ASSERT_EQ(skel->bss->delete_result, 0, "delete_ok");
+
+	skel->bss->test_op = 0;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "recreate");
+	ASSERT_EQ(skel->bss->result, 1, "recreate_ok");
+
+	skel->bss->test_op = 1;
+	err = getsockopt(fd, 0xdead, 0xbeef, &val, &len);
+	ASSERT_OK(err, "get_after_recreate");
+	ASSERT_EQ(skel->bss->val_a, 2, "val_a_fresh");
+
+done:
+	if (fd != -1)
+		close(fd);
+	sk_ls_reserve__destroy(skel);
+}
+
+void test_ns_sk_ls_reserve(void)
+{
+	if (!reserve_enabled()) {
+		test__skip();
+		return;
+	}
+
+	cgroup_fd = test__join_cgroup("/sk_ls_reserve");
+	if (!ASSERT_OK_FD(cgroup_fd, "join_cgroup"))
+		return;
+
+	if (test__start_subtest("get_create_delete"))
+		test_get_create_delete();
+	if (test__start_subtest("multiple_maps"))
+		test_multiple_maps();
+	if (test__start_subtest("create_with_value"))
+		test_create_with_value();
+	if (test__start_subtest("delete_nonexistent"))
+		test_delete_nonexistent();
+	if (test__start_subtest("multiple_sockets"))
+		test_multiple_sockets();
+	if (test__start_subtest("recreate_after_delete"))
+		test_recreate_after_delete();
+
+	close(cgroup_fd);
+}

--- a/tools/testing/selftests/bpf/progs/sk_ls_reserve.c
+++ b/tools/testing/selftests/bpf/progs/sk_ls_reserve.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 Meta Platforms, Inc. and affiliates. */
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+struct val {
+	__u32 a;
+	__u32 b;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_SK_STORAGE);
+	__uint(map_flags, 0);
+	__type(key, int);
+	__type(value, struct val);
+} sk_stg SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_SK_STORAGE);
+	__uint(map_flags, 0);
+	__type(key, int);
+	__type(value, struct val);
+} sk_stg2 SEC(".maps");
+
+int test_op;
+int result;
+int result2;
+int delete_result;
+__u32 val_a;
+__u32 val2_a;
+
+SEC("cgroup/getsockopt")
+int get_create(struct bpf_sockopt *ctx)
+{
+	struct val *v, *v2;
+
+	if (ctx->level != 0xdead || ctx->optname != 0xbeef)
+		return 1;
+
+	if (test_op == 0) {
+		v = bpf_sk_storage_get(&sk_stg, ctx->sk, 0, BPF_SK_STORAGE_GET_F_CREATE);
+		if (v) {
+			v->a += 1;
+			result = 1;
+		} else {
+			result = 0;
+		}
+	} else if (test_op == 1) {
+		v = bpf_sk_storage_get(&sk_stg, ctx->sk, 0, 0);
+		if (v) {
+			v->a += 1;
+			val_a = v->a;
+			result = 1;
+		} else {
+			result = 0;
+		}
+	} else if (test_op == 2) {
+		delete_result = bpf_sk_storage_delete(&sk_stg, ctx->sk);
+		result = (delete_result == 0) ? 1 : 0;
+	} else if (test_op == 3) {
+		v = bpf_sk_storage_get(&sk_stg, ctx->sk, 0, BPF_SK_STORAGE_GET_F_CREATE);
+		v2 = bpf_sk_storage_get(&sk_stg2, ctx->sk, 0, BPF_SK_STORAGE_GET_F_CREATE);
+		if (v) {
+			v->a += 1;
+			val_a = v->a;
+			result = 1;
+		} else {
+			result = 0;
+		}
+		if (v2) {
+			v2->a += 10;
+			val2_a = v2->a;
+			result2 = 1;
+		} else {
+			result2 = 0;
+		}
+	} else if (test_op == 4) {
+		v = bpf_sk_storage_get(&sk_stg, ctx->sk, 0, 0);
+		v2 = bpf_sk_storage_get(&sk_stg2, ctx->sk, 0, 0);
+		result = v ? 1 : 0;
+		result2 = v2 ? 1 : 0;
+		if (v)
+			val_a = v->a;
+		if (v2)
+			val2_a = v2->a;
+	} else if (test_op == 5) {
+		delete_result = bpf_sk_storage_delete(&sk_stg2, ctx->sk);
+	} else if (test_op == 6) {
+		struct val init = { .a = 100, .b = 200 };
+
+		v = bpf_sk_storage_get(&sk_stg, ctx->sk, &init, BPF_SK_STORAGE_GET_F_CREATE);
+		if (v) {
+			val_a = v->a;
+			result = 1;
+		} else {
+			result = 0;
+		}
+	} else if (test_op == 7) {
+		v = bpf_sk_storage_get(&sk_stg, ctx->sk, 0, BPF_SK_STORAGE_GET_F_CREATE);
+		if (v) {
+			v->a += 1;
+			val_a = v->a;
+			result = 1;
+		} else {
+			result = 0;
+		}
+	} else if (test_op == 8) {
+		delete_result = bpf_sk_storage_delete(&sk_stg, ctx->sk);
+	}
+
+	ctx->retval = 0;
+	return 1;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/tools/testing/selftests/bpf/progs/sk_storage_bench.c
+++ b/tools/testing/selftests/bpf/progs/sk_storage_bench.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 Meta Platforms, Inc. and affiliates. */
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+struct val {
+	__u64 cnt;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_SK_STORAGE);
+	__uint(map_flags, 0);
+	__type(key, int);
+	__type(value, struct val);
+} sk_stg SEC(".maps");
+
+long hits;
+
+/*
+ * Driven by a bpf_iter/tcp read() pass.  One read() visits every TCP
+ * socket in the netns, calling bpf_sk_storage_get() on each.  This
+ * amortizes the syscall over all sockets and touches a different (cold)
+ * socket each call, isolating the storage-access cost.
+ */
+SEC("iter/tcp")
+int iter_sk_storage_get(struct bpf_iter__tcp *ctx)
+{
+	struct sock_common *sk_common = ctx->sk_common;
+	struct val *v;
+
+	if (!sk_common)
+		return 0;
+
+	v = bpf_sk_storage_get(&sk_stg, sk_common, 0,
+			       BPF_SK_STORAGE_GET_F_CREATE);
+	if (v) {
+		v->cnt++;
+		__sync_fetch_and_add(&hits, 1);
+	}
+
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
This series adds an option to embed BPF sk_storage directly inside the
socket allocation, eliminating the pointer chase that bpf_sk_storage_get()
performs today.  On a production fleet that runs sockops/getsockopt and
per-packet (sched_cls) BPF programs, bpf_sk_storage_get() is one of the
hottest kernel functions, almost entirely due to data-cache misses.

The problem
===========

A BPF sk_storage lookup walks three separately-allocated objects.
bpf_sk_storage_get() -> bpf_sk_storage_lookup() -> bpf_local_storage_lookup():

    /* net/core/bpf_sk_storage.c */
    sk_storage = rcu_dereference(sk->sk_bpf_storage);     /* (1) */
    ...
    /* include/linux/bpf_local_storage.h */
    sdata = rcu_dereference(local_storage->cache[smap->cache_idx]); /* (2) */
    if (sdata && rcu_access_pointer(sdata->smap) == smap) /* (3) */
            return sdata;

Each step dereferences a pointer into a different allocation:

```
    (1) sk->sk_bpf_storage   -> struct bpf_local_storage  (kmalloc'd)
    (2) local_storage->cache -> struct bpf_local_storage_data, which lives
                                inside a struct bpf_local_storage_elem
                                (kmalloc'd, separate from local_storage)
    (3) sdata->smap          -> read to confirm the elem belongs to this map

         sk ────▶ bpf_local_storage ───▶ bpf_local_storage_elem ──▶ data
    (sock slab)            (kmalloc)             (kmalloc)
```

These three objects are allocated at different times from different slabs,
so on a host with hundreds of thousands of live sockets they sit on
unrelated cache lines.  The lookup is a dependent load chain: each miss
must complete before the next address is known, so the latency is three
serialized cache misses on the hot path.

This shows up directly in a cycles/dcache profile.  In the
bpf_sk_storage_get() disassembly the misses land on exactly these three
dereferences (arm64, production kernel):

     0.56  │ ldr  x0, [x21, #760]        ; x0 = sk->sk_bpf_storage
    43.70  │ cbz  x0, ...                ; (1)
     0.52  │ ldr  x19, [x0, x1, lsl #3]  ; x19 = local_storage->cache[idx]
    24.60  │ cbz  x19, ...               ; (2)
     1.37  │ ldr  x1, [x19]              ; x1 = sdata->smap
    20.30  │ cmp  x22, x1                ; (3)

The three dependent dereferences account for ~88% of the function's
L1-dcache misses.

The approach
============

When booted with bpf_sk_reserve=N, every socket slab is enlarged by N
bytes placed in front of struct sock (struct sock still starts on a new cacheline):

    [ reserved area ][ struct sock / tcp_sock / ... ]
    ^                 ^
    slab start       sk (returned to callers)

prot->obj_size is left unchanged so sk_prot_clear_nulls() and sock_copy()
keep operating on struct sock only; only the slab/kmalloc size grows.  The
reserve is rounded up to a cache line so sk stays cache-line aligned and
struct sock's own layout is unperturbed.  When bpf_sk_reserve is 0 the
feature compiles to identity macros and there is no change.

An sk_storage map can claim a fixed slot in this area.  Lookup then
becomes a single load at a constant negative offset from sk:

    /* one allocation, one cache line, no chase */
    data  = (void *)sk - smap->reserve_off;
    owner = ((u32 *)data) - 1;
    if (*owner == map->id)         /* created for this sk+map? */
            return data;

The 3-load chase collapses to a single owner_id load adjacent to the
socket.  In the same profile the reserved path is one cold load (the
owner compare), with bpf_local_storage_lookup() gone entirely.

A u32 owner_id prefix precedes each slot's value.  It records the
owning map's id and provides three things without a separate "created"
bitmap: a not-yet-created slot reads owner 0 (no map has id 0); delete
zeroes the owner; and slot reuse after a map is freed is safe, since a
new map with a different id sees the stale owner as "not mine" and
lazily reinitializes.

Reservation is opt-in.  sk_storage historically requires
BPF_F_NO_PREALLOC; that flag now selects the existing hash path
unchanged.  Dropping it opts into reserved storage, which requires
bpf_sk_reserve to be configured -- if there is no room (or the feature
is off) map creation fails with -ENOSPC rather than silently using the
slower path.  Maps with kptr/uptr fields are not eligible (their
lifetime cannot be tied to the socket allocation) and use the hash path.

Socket clone is handled for free: the reserved area is a flat byte
range in front of struct sock, so sk_clone() copies it (data and
owner_id) wholesale from parent to child.  Every reserved map is
therefore cloned unconditionally; BPF_F_CLONE has no additional effect
on the reserved path.