### PR TITLE
call_rcu_nolock()

### DIFF
--- a/include/linux/srcutiny.h
+++ b/include/linux/srcutiny.h
@@ -12,6 +12,7 @@
 #define _LINUX_SRCU_TINY_H
 
 #include <linux/irq_work_types.h>
+#include <linux/llist.h>
 #include <linux/swait.h>
 
 struct srcu_struct {
@@ -26,6 +27,8 @@ struct srcu_struct {
 	struct rcu_head **srcu_cb_tail;	/* Pending callbacks: Tail. */
 	struct work_struct srcu_work;	/* For driving grace periods. */
 	struct irq_work srcu_irq_work;	/* Defer schedule_work() to irq work. */
+	struct llist_head nmi_cbs;	/* Callbacks staged from NMI. */
+	struct irq_work nmi_iw;		/* Registers nmi_cbs later. */
 #ifdef CONFIG_DEBUG_LOCK_ALLOC
 	struct lockdep_map dep_map;
 #endif /* #ifdef CONFIG_DEBUG_LOCK_ALLOC */
@@ -33,6 +36,7 @@ struct srcu_struct {
 
 void srcu_drive_gp(struct work_struct *wp);
 void srcu_tiny_irq_work(struct irq_work *irq_work);
+void srcu_nmi_drain(struct irq_work *irq_work);
 
 #define __SRCU_STRUCT_INIT(name, __ignored, ___ignored, ____ignored)	\
 {									\
@@ -40,6 +44,8 @@ void srcu_tiny_irq_work(struct irq_work *irq_work);
 	.srcu_cb_tail = &name.srcu_cb_head,				\
 	.srcu_work = __WORK_INITIALIZER(name.srcu_work, srcu_drive_gp),	\
 	.srcu_irq_work = { .func = srcu_tiny_irq_work },		\
+	.nmi_cbs = LLIST_HEAD_INIT(name.nmi_cbs),			\
+	.nmi_iw = { .func = srcu_nmi_drain },				\
 	__SRCU_DEP_MAP_INIT(name)					\
 }
 
@@ -131,10 +137,7 @@ static inline void synchronize_srcu_expedited(struct srcu_struct *ssp)
 	synchronize_srcu(ssp);
 }
 
-static inline void srcu_barrier(struct srcu_struct *ssp)
-{
-	synchronize_srcu(ssp);
-}
+void srcu_barrier(struct srcu_struct *ssp);
 
 static inline void srcu_expedite_current(struct srcu_struct *ssp) { }
 #define srcu_check_read_flavor(ssp, read_flavor) do { } while (0)

--- a/include/linux/srcutree.h
+++ b/include/linux/srcutree.h
@@ -46,6 +46,9 @@ struct srcu_data {
 	struct llist_head nmi_cbs;		/* Callbacks staged from NMI. */
 	struct llist_node nmi_link;		/* Links onto the per-CPU NMI */
 						/*  drain list; see __call_srcu(). */
+#ifdef CONFIG_PROVE_RCU
+	unsigned long nmi_ip;			/* Caller of a deferred call_srcu(). */
+#endif
 	struct rcu_head srcu_barrier_head;	/* For srcu_barrier() use. */
 	struct rcu_head srcu_ec_head;		/* For srcu_expedite_current() use. */
 	int srcu_ec_state;			/*  State for srcu_expedite_current(). */

--- a/include/linux/srcutree.h
+++ b/include/linux/srcutree.h
@@ -13,6 +13,8 @@
 
 #include <linux/rcu_node_tree.h>
 #include <linux/completion.h>
+#include <linux/irq_work_types.h>
+#include <linux/llist.h>
 
 struct srcu_node;
 struct srcu_struct;
@@ -41,6 +43,9 @@ struct srcu_data {
 	bool srcu_cblist_invoking;		/* Invoking these CBs? */
 	struct timer_list delay_work;		/* Delay for CB invoking */
 	struct work_struct work;		/* Context for CB invoking. */
+	struct llist_head nmi_cbs;		/* Callbacks staged from NMI. */
+	struct llist_node nmi_link;		/* Links onto the per-CPU NMI */
+						/*  drain list; see __call_srcu(). */
 	struct rcu_head srcu_barrier_head;	/* For srcu_barrier() use. */
 	struct rcu_head srcu_ec_head;		/* For srcu_expedite_current() use. */
 	int srcu_ec_state;			/*  State for srcu_expedite_current(). */

--- a/kernel/rcu/Kconfig
+++ b/kernel/rcu/Kconfig
@@ -10,6 +10,8 @@ config TREE_RCU
 	default y if SMP
 	# Dynticks-idle tracking
 	select CONTEXT_TRACKING_IDLE
+	# call_rcu() defers to irq_work when called from NMI
+	select IRQ_WORK
 	help
 	  This option selects the RCU implementation that is
 	  designed for very large SMP system with hundreds or
@@ -32,6 +34,8 @@ config PREEMPT_RCU
 config TINY_RCU
 	bool
 	default y if !PREEMPT_RCU && !SMP
+	# call_rcu() defers to irq_work when called from NMI
+	select IRQ_WORK
 	help
 	  This option selects the RCU implementation that is
 	  designed for UP systems from which real-time response

--- a/kernel/rcu/Kconfig
+++ b/kernel/rcu/Kconfig
@@ -60,12 +60,16 @@ config RCU_EXPERT
 config TINY_SRCU
 	bool
 	default y if TINY_RCU
+	# call_srcu() defers to irq_work when called from NMI
+	select IRQ_WORK
 	help
 	  This option selects the single-CPU non-preemptible version of SRCU.
 
 config TREE_SRCU
 	bool
 	default y if !TINY_RCU
+	# call_srcu() defers to irq_work when called from NMI
+	select IRQ_WORK
 	help
 	  This option selects the full-fledged version of SRCU.
 

--- a/kernel/rcu/rcutorture.c
+++ b/kernel/rcu/rcutorture.c
@@ -48,6 +48,7 @@
 #include <linux/tick.h>
 #include <linux/rcupdate_trace.h>
 #include <linux/nmi.h>
+#include <linux/perf_event.h>
 
 #include "rcu.h"
 
@@ -212,6 +213,7 @@ static long n_rcu_torture_boost_ktrerror;
 static long n_rcu_torture_boost_failure;
 static long n_rcu_torture_boosts;
 static atomic_long_t n_rcu_torture_timers;
+static atomic_long_t n_rcu_torture_nmi_call;
 static long n_barrier_attempts;
 static long n_barrier_successes; /* did rcu_barrier test succeed? */
 static unsigned long n_read_exits;
@@ -428,6 +430,7 @@ struct rcu_torture_ops {
 	int (*get_gpwrap_count)(int cpu);
 	long cbflood_max;
 	int irq_capable;
+	int nmi_capable;
 	int can_boost;
 	int extendables;
 	int slow_gps;
@@ -640,6 +643,7 @@ static struct rcu_torture_ops rcu_ops = {
 	.extendables		= RCUTORTURE_MAX_EXTEND,
 	.debug_objects		= 1,
 	.start_poll_irqsoff	= 1,
+	.nmi_capable		= 1,
 	.name			= "rcu"
 };
 
@@ -929,6 +933,7 @@ static struct rcu_torture_ops srcu_ops = {
 	.debug_objects	= 1,
 	.have_up_down	= IS_ENABLED(CONFIG_TINY_SRCU)
 				? 0 : SRCU_READ_FLAVOR_NORMAL | SRCU_READ_FLAVOR_FAST_UPDOWN,
+	.nmi_capable	= 1,
 	.name		= "srcu"
 };
 
@@ -992,6 +997,7 @@ static struct rcu_torture_ops srcud_ops = {
 	.debug_objects	= 1,
 	.have_up_down	= IS_ENABLED(CONFIG_TINY_SRCU)
 				? 0 : SRCU_READ_FLAVOR_NORMAL | SRCU_READ_FLAVOR_FAST_UPDOWN,
+	.nmi_capable	= 1,
 	.name		= "srcud"
 };
 
@@ -1246,6 +1252,7 @@ static struct rcu_torture_ops tasks_tracing_ops = {
 	.cbflood_max	= 50000,
 	.irq_capable	= 1,
 	.slow_gps	= 1,
+	.nmi_capable	= 1,
 	.name		= "tasks-tracing"
 };
 
@@ -2532,11 +2539,95 @@ static bool rcu_torture_one_read(struct torture_random_state *trsp, long myid)
 static DEFINE_TORTURE_RANDOM_PERCPU(rcu_torture_timer_rand);
 
 /*
+ * Exercise ->call() from NMI context for flavors that advertise ->nmi_capable.
+ * A per-CPU hardware perf counter overflows into an NMI -- a real NMI on x86,
+ * or a pseudo-NMI on arm64 booted with irqchip.gicv3_pseudo_nmi=1 -- and its
+ * handler submits one preallocated callback via ->call().  Only one callback is
+ * in flight at a time (guarded by an atomic), which avoids allocating in NMI
+ * and is enough to exercise the deferral.  This mirrors how BPF programs reach
+ * ->call() from NMI.  Requires a hardware PMU; when the overflow is not an NMI
+ * the handler does nothing.
+ */
+#ifdef CONFIG_PERF_EVENTS
+static struct perf_event_attr rcu_torture_nmi_attr = {
+	.type		= PERF_TYPE_HARDWARE,
+	.config		= PERF_COUNT_HW_CPU_CYCLES,
+	.size		= sizeof(struct perf_event_attr),
+	.pinned		= 1,
+	.disabled	= 1,
+	.freq		= 1,
+	.sample_freq	= 1000,
+};
+
+static struct perf_event **rcu_torture_nmi_events;
+static struct rcu_head rcu_torture_nmi_rh;
+static atomic_t rcu_torture_nmi_rh_inuse;
+
+static void rcu_torture_nmi_cb(struct rcu_head *rhp)
+{
+	atomic_set(&rcu_torture_nmi_rh_inuse, 0);
+}
+
+static void rcu_torture_nmi_overflow(struct perf_event *event,
+				     struct perf_sample_data *data,
+				     struct pt_regs *regs)
+{
+	if (!in_nmi())
+		return;
+	if (cur_ops->call && !atomic_xchg(&rcu_torture_nmi_rh_inuse, 1)) {
+		cur_ops->call(&rcu_torture_nmi_rh, rcu_torture_nmi_cb);
+		atomic_long_inc(&n_rcu_torture_nmi_call);
+	}
+}
+
+static void rcu_torture_nmi_init(void)
+{
+	struct perf_event *event;
+	int cpu;
+
+	if (!cur_ops->nmi_capable || !cur_ops->call)
+		return;
+	rcu_torture_nmi_events = kcalloc(nr_cpu_ids, sizeof(*rcu_torture_nmi_events),
+					 GFP_KERNEL);
+	if (!rcu_torture_nmi_events)
+		return;
+	for_each_online_cpu(cpu) {
+		event = perf_event_create_kernel_counter(&rcu_torture_nmi_attr, cpu,
+							 NULL, rcu_torture_nmi_overflow, NULL);
+		if (IS_ERR(event))
+			continue;
+		rcu_torture_nmi_events[cpu] = event;
+		perf_event_enable(event);
+	}
+}
+
+static void rcu_torture_nmi_cleanup(void)
+{
+	int cpu;
+
+	if (!rcu_torture_nmi_events)
+		return;
+	for_each_possible_cpu(cpu) {
+		if (!rcu_torture_nmi_events[cpu])
+			continue;
+		perf_event_disable(rcu_torture_nmi_events[cpu]);
+		perf_event_release_kernel(rcu_torture_nmi_events[cpu]);
+	}
+	kfree(rcu_torture_nmi_events);
+	rcu_torture_nmi_events = NULL;
+}
+#else /* #ifdef CONFIG_PERF_EVENTS */
+static void rcu_torture_nmi_init(void) { }
+static void rcu_torture_nmi_cleanup(void) { }
+#endif /* #else #ifdef CONFIG_PERF_EVENTS */
+
+/*
  * RCU torture reader from timer handler.  Dereferences rcu_torture_current,
  * incrementing the corresponding element of the pipeline array.  The
  * counter in the element should never be greater than 1, otherwise, the
  * RCU implementation is broken.
  */
+
 static void rcu_torture_timer(struct timer_list *unused)
 {
 	WARN_ON_ONCE(!in_serving_softirq());
@@ -2865,6 +2956,7 @@ rcu_torture_stats_print(void)
 		data_race(n_barrier_attempts),
 		data_race(n_rcu_torture_barrier_error));
 	pr_cont("read-exits: %ld ", data_race(n_read_exits)); // Statistic.
+	pr_cont("nmi-calls: %ld ", atomic_long_read(&n_rcu_torture_nmi_call));
 	pr_cont("nocb-toggles: %ld:%ld ",
 		atomic_long_read(&n_nocb_offload), atomic_long_read(&n_nocb_deoffload));
 	pr_cont("gpwraps: %ld\n", n_gpwraps);
@@ -4143,6 +4235,8 @@ rcu_torture_cleanup(void)
 		kfree(reader_tasks);
 		reader_tasks = NULL;
 	}
+	/* Readers (the only NMI firers) are stopped; safe to unregister now. */
+	rcu_torture_nmi_cleanup();
 	kfree(rcu_torture_reader_mbchk);
 	rcu_torture_reader_mbchk = NULL;
 
@@ -4655,6 +4749,8 @@ rcu_torture_init(void)
 		firsterr = -ENOMEM;
 		goto unwind;
 	}
+	/* Register the NMI handler before readers start firing self-IPIs. */
+	rcu_torture_nmi_init();
 	for (i = 0; i < nrealreaders; i++) {
 		rcu_torture_reader_mbchk[i].rtc_chkrdr = -1;
 		firsterr = torture_create_kthread(rcu_torture_reader, (void *)i,

--- a/kernel/rcu/srcutiny.c
+++ b/kernel/rcu/srcutiny.c
@@ -10,6 +10,7 @@
 
 #include <linux/export.h>
 #include <linux/irq_work.h>
+#include <linux/llist.h>
 #include <linux/mutex.h>
 #include <linux/preempt.h>
 #include <linux/rcupdate_wait.h>
@@ -43,6 +44,8 @@ static int init_srcu_struct_fields(struct srcu_struct *ssp)
 	INIT_WORK(&ssp->srcu_work, srcu_drive_gp);
 	INIT_LIST_HEAD(&ssp->srcu_work.entry);
 	init_irq_work(&ssp->srcu_irq_work, srcu_tiny_irq_work);
+	init_llist_head(&ssp->nmi_cbs);
+	init_irq_work(&ssp->nmi_iw, srcu_nmi_drain);
 	return 0;
 }
 
@@ -216,10 +219,43 @@ static void srcu_gp_start_if_needed(struct srcu_struct *ssp)
  * Enqueue an SRCU callback on the specified srcu_struct structure,
  * initiating grace-period processing if it is not already running.
  */
+/*
+ * call_srcu() cannot be invoked from NMI context: its enqueue runs under
+ * local_irq_save() (which does not mask NMIs) and appends to the callback list
+ * with a non-atomic multi-store that an NMI could corrupt.
+ *
+ * When called from NMI, stage the callback on this srcu_struct's lockless list
+ * (llist_add() is a single cmpxchg and hence NMI-safe) and schedule an irq_work
+ * (its local enqueue is NMI-safe) that hands it back to call_srcu() from
+ * ordinary context.
+ */
+void srcu_nmi_drain(struct irq_work *iw)
+{
+	struct srcu_struct *ssp = container_of(iw, struct srcu_struct, nmi_iw);
+	struct llist_node *node, *next;
+
+	/* llist_add() prepends, so reverse to preserve call_srcu() order. */
+	node = llist_reverse_order(llist_del_all(&ssp->nmi_cbs));
+	llist_for_each_safe(node, next, node) {
+		struct rcu_head *rhp = (struct rcu_head *)node;
+
+		call_srcu(ssp, rhp, rhp->func);
+	}
+}
+EXPORT_SYMBOL_GPL(srcu_nmi_drain);
+
 void call_srcu(struct srcu_struct *ssp, struct rcu_head *rhp,
 	       rcu_callback_t func)
 {
 	unsigned long flags;
+
+	/* NMI callers cannot touch the callback list; defer via irq_work. */
+	if (in_nmi()) {
+		rhp->func = func;
+		if (llist_add((struct llist_node *)rhp, &ssp->nmi_cbs))
+			irq_work_queue(&ssp->nmi_iw);
+		return;
+	}
 
 	rhp->func = func;
 	rhp->next = NULL;
@@ -259,6 +295,17 @@ void synchronize_srcu(struct srcu_struct *ssp)
 	destroy_rcu_head_on_stack(&rs.head);
 }
 EXPORT_SYMBOL_GPL(synchronize_srcu);
+
+/*
+ * Wait for in-flight call_srcu() callbacks, including any staged from NMI
+ * context, which are first handed to call_srcu() via irq_work_sync().
+ */
+void srcu_barrier(struct srcu_struct *ssp)
+{
+	irq_work_sync(&ssp->nmi_iw);
+	synchronize_srcu(ssp);
+}
+EXPORT_SYMBOL_GPL(srcu_barrier);
 
 /*
  * get_state_synchronize_srcu - Provide an end-of-grace-period cookie

--- a/kernel/rcu/srcutree.c
+++ b/kernel/rcu/srcutree.c
@@ -20,6 +20,7 @@
 #include <linux/percpu.h>
 #include <linux/preempt.h>
 #include <linux/irq_work.h>
+#include <linux/llist.h>
 #include <linux/rcupdate_wait.h>
 #include <linux/sched.h>
 #include <linux/smp.h>
@@ -79,6 +80,25 @@ static void process_srcu(struct work_struct *work);
 static void srcu_irq_work(struct irq_work *work);
 static void srcu_delay_timer(struct timer_list *t);
 
+static void srcu_nmi_drain(struct irq_work *iw);
+
+/*
+ * NMI-safe deferral for call_srcu().  A callback queued from NMI is staged on
+ * its srcu_data's ->nmi_cbs, and that srcu_data is chained (via ->nmi_link)
+ * onto this per-CPU list, which a single statically-initialized irq_work drains
+ * from ordinary context.  Making the irq_work global (one per CPU rather than
+ * one per srcu_struct) means it needs no per-srcu_struct initialization, so the
+ * NMI path never has to run check_init_srcu_struct().
+ */
+struct srcu_nmi_defer {
+	struct llist_head	list;
+	struct irq_work		iw;
+};
+
+static DEFINE_PER_CPU(struct srcu_nmi_defer, srcu_nmi_defer) = {
+	.iw = IRQ_WORK_INIT(srcu_nmi_drain),
+};
+
 /*
  * Initialize SRCU per-CPU data.  Note that statically allocated
  * srcu_struct structures might already have srcu_read_lock() and
@@ -107,6 +127,12 @@ static void init_srcu_struct_data(struct srcu_struct *ssp)
 		sdp->cpu = cpu;
 		INIT_WORK(&sdp->work, srcu_invoke_callbacks);
 		timer_setup(&sdp->delay_work, srcu_delay_timer, 0);
+		/*
+		 * ->nmi_cbs and ->nmi_link are not initialized here: both are
+		 * valid when zeroed, and initializing them at this (possibly
+		 * lazy) point could clobber state an NMI already staged.  See
+		 * __call_srcu().
+		 */
 		sdp->ssp = ssp;
 	}
 }
@@ -721,6 +747,9 @@ void cleanup_srcu_struct(struct srcu_struct *ssp)
 		return; /* Just leak it! */
 	/* Wait for irq_work to finish first as it may queue a new work. */
 	irq_work_sync(&sup->irq_work);
+	/* Drain any NMI-staged callbacks (shared irq_work) before freeing ->sda. */
+	for_each_possible_cpu(cpu)
+		irq_work_sync(&per_cpu(srcu_nmi_defer, cpu).iw);
 	flush_delayed_work(&sup->work);
 	for_each_possible_cpu(cpu) {
 		struct srcu_data *sdp = per_cpu_ptr(ssp->sda, cpu);
@@ -1430,9 +1459,52 @@ static unsigned long srcu_gp_start_if_needed(struct srcu_struct *ssp,
  * srcu_read_lock(), and srcu_read_unlock() that are all passed the same
  * srcu_struct structure.
  */
+/*
+ * call_srcu() cannot be invoked from NMI context: srcu_gp_start_if_needed()
+ * runs under local_irq_save() (which does not mask NMIs) and appends to the
+ * per-CPU srcu_cblist under a raw spinlock -- an NMI could corrupt the list or
+ * deadlock on the lock.
+ *
+ * When called from NMI, stage the callback on the target srcu_data's lockless
+ * ->nmi_cbs list (llist_add() is a single cmpxchg and hence NMI-safe), chain
+ * that srcu_data onto this CPU's global NMI-drain list, and kick the per-CPU
+ * srcu_nmi_defer irq_work (its local enqueue is NMI-safe).  The irq_work hands
+ * each staged callback to the ordinary __call_srcu() from benign context.  As
+ * call_rcu_tasks_trace() is call_srcu() on a dedicated srcu_struct, it becomes
+ * NMI-safe too.
+ *
+ * The NMI path never runs check_init_srcu_struct() (it takes a lock and, on
+ * first use, allocates).  It needs only ssp->sda -- populated for the lifetime
+ * of any defined or init_srcu_struct()'d srcu_struct -- and it records ssp in
+ * the queued srcu_data (->ssp) so the drain can find the srcu_struct even
+ * before the lazy init_srcu_struct_data() has run.  Full initialization happens
+ * later, via check_init_srcu_struct() from the __call_srcu() the drain invokes.
+ */
 static void __call_srcu(struct srcu_struct *ssp, struct rcu_head *rhp,
 			rcu_callback_t func, bool do_norm)
 {
+	/* NMI callers cannot touch the srcu_cblist or its lock; defer. */
+	if (in_nmi()) {
+		struct srcu_data *sdp = this_cpu_ptr(ssp->sda);
+
+		rhp->func = func;
+		if (llist_add((struct llist_node *)rhp, &sdp->nmi_cbs)) {
+			/*
+			 * This srcu_data had no pending NMI callbacks, so record
+			 * the srcu_struct the drain will need and chain it onto
+			 * this CPU's drain list.  ->ssp is only ever set to this
+			 * same value, so the store is safe against a concurrent
+			 * init_srcu_struct_data().
+			 */
+			struct srcu_nmi_defer *sndp = this_cpu_ptr(&srcu_nmi_defer);
+
+			sdp->ssp = ssp;
+			if (llist_add(&sdp->nmi_link, &sndp->list))
+				irq_work_queue(&sndp->iw);
+		}
+		return;
+	}
+
 	if (debug_rcu_head_queue(rhp)) {
 		/* Probable double call_srcu(), so leak the callback. */
 		WRITE_ONCE(rhp->func, srcu_leak_callback);
@@ -1441,6 +1513,31 @@ static void __call_srcu(struct srcu_struct *ssp, struct rcu_head *rhp,
 	}
 	rhp->func = func;
 	(void)srcu_gp_start_if_needed(ssp, rhp, do_norm);
+}
+
+/*
+ * Drain this CPU's NMI-staged callbacks: for each queued srcu_data, hand its
+ * callbacks to the ordinary __call_srcu(), which does the deferred checking and
+ * initialization.  Runs from irq_work context, where __call_srcu() is safe.
+ */
+static void srcu_nmi_drain(struct irq_work *iw)
+{
+	struct srcu_nmi_defer *sndp = container_of(iw, struct srcu_nmi_defer, iw);
+	struct llist_node *snode, *snext;
+
+	llist_for_each_safe(snode, snext, llist_del_all(&sndp->list)) {
+		struct srcu_data *sdp = container_of(snode, struct srcu_data, nmi_link);
+		struct srcu_struct *ssp = sdp->ssp;
+		struct llist_node *cnode, *cnext;
+
+		/* llist_add() prepends, so reverse to preserve call_srcu() order. */
+		cnode = llist_reverse_order(llist_del_all(&sdp->nmi_cbs));
+		llist_for_each_safe(cnode, cnext, cnode) {
+			struct rcu_head *rhp = (struct rcu_head *)cnode;
+
+			__call_srcu(ssp, rhp, rhp->func, true);
+		}
+	}
 }
 
 /**
@@ -1697,9 +1794,21 @@ void srcu_barrier(struct srcu_struct *ssp)
 {
 	int cpu;
 	int idx;
-	unsigned long s = rcu_seq_snap(&ssp->srcu_sup->srcu_barrier_seq);
+	unsigned long s;
 
 	check_init_srcu_struct(ssp);
+
+	/*
+	 * Hand any callbacks staged from NMI context to __call_srcu() before
+	 * snapshotting the barrier sequence, so that they are covered whether
+	 * we do the barrier ourselves or piggyback on a concurrent one.  The
+	 * drain irq_work is shared by all srcu_structs, so this may also drain
+	 * other srcu_structs' NMI callbacks, which is harmless.
+	 */
+	for_each_possible_cpu(cpu)
+		irq_work_sync(&per_cpu(srcu_nmi_defer, cpu).iw);
+
+	s = rcu_seq_snap(&ssp->srcu_sup->srcu_barrier_seq);
 	mutex_lock(&ssp->srcu_sup->srcu_barrier_mutex);
 	if (rcu_seq_done(&ssp->srcu_sup->srcu_barrier_seq, s)) {
 		smp_mb(); /* Force ordering following return. */

--- a/kernel/rcu/srcutree.c
+++ b/kernel/rcu/srcutree.c
@@ -1481,7 +1481,7 @@ static unsigned long srcu_gp_start_if_needed(struct srcu_struct *ssp,
  * later, via check_init_srcu_struct() from the __call_srcu() the drain invokes.
  */
 static void __call_srcu(struct srcu_struct *ssp, struct rcu_head *rhp,
-			rcu_callback_t func, bool do_norm)
+			rcu_callback_t func, bool do_norm, unsigned long ip)
 {
 	/* NMI callers cannot touch the srcu_cblist or its lock; defer. */
 	if (in_nmi()) {
@@ -1499,6 +1499,9 @@ static void __call_srcu(struct srcu_struct *ssp, struct rcu_head *rhp,
 			struct srcu_nmi_defer *sndp = this_cpu_ptr(&srcu_nmi_defer);
 
 			sdp->ssp = ssp;
+#ifdef CONFIG_PROVE_RCU
+			sdp->nmi_ip = ip;
+#endif
 			if (llist_add(&sdp->nmi_link, &sndp->list))
 				irq_work_queue(&sndp->iw);
 		}
@@ -1508,7 +1511,8 @@ static void __call_srcu(struct srcu_struct *ssp, struct rcu_head *rhp,
 	if (debug_rcu_head_queue(rhp)) {
 		/* Probable double call_srcu(), so leak the callback. */
 		WRITE_ONCE(rhp->func, srcu_leak_callback);
-		WARN_ONCE(1, "call_srcu(): Leaked duplicate callback\n");
+		WARN_ONCE(1, "call_srcu(): Leaked duplicate callback from %pS\n",
+			  (void *)ip);
 		return;
 	}
 	rhp->func = func;
@@ -1535,7 +1539,7 @@ static void srcu_nmi_drain(struct irq_work *iw)
 		llist_for_each_safe(cnode, cnext, cnode) {
 			struct rcu_head *rhp = (struct rcu_head *)cnode;
 
-			__call_srcu(ssp, rhp, rhp->func, true);
+			__call_srcu(ssp, rhp, rhp->func, true, _THIS_IP_);
 		}
 	}
 }
@@ -1564,7 +1568,7 @@ static void srcu_nmi_drain(struct irq_work *iw)
 void call_srcu(struct srcu_struct *ssp, struct rcu_head *rhp,
 	       rcu_callback_t func)
 {
-	__call_srcu(ssp, rhp, func, true);
+	__call_srcu(ssp, rhp, func, true, _RET_IP_);
 }
 EXPORT_SYMBOL_GPL(call_srcu);
 
@@ -1589,7 +1593,7 @@ static void __synchronize_srcu(struct srcu_struct *ssp, bool do_norm)
 	check_init_srcu_struct(ssp);
 	init_completion(&rcu.completion);
 	init_rcu_head_on_stack(&rcu.head);
-	__call_srcu(ssp, &rcu.head, wakeme_after_rcu, do_norm);
+	__call_srcu(ssp, &rcu.head, wakeme_after_rcu, do_norm, _RET_IP_);
 	wait_for_completion(&rcu.completion);
 	destroy_rcu_head_on_stack(&rcu.head);
 
@@ -1859,7 +1863,8 @@ static void srcu_expedite_current_cb(struct rcu_head *rhp)
 	raw_spin_unlock_irqrestore_rcu_node(sdp, flags);
 	// If needed, requeue ourselves as an expedited SRCU callback.
 	if (needcb)
-		__call_srcu(sdp->ssp, &sdp->srcu_ec_head, srcu_expedite_current_cb, false);
+		__call_srcu(sdp->ssp, &sdp->srcu_ec_head, srcu_expedite_current_cb,
+			    false, _RET_IP_);
 }
 
 /**
@@ -1892,7 +1897,8 @@ void srcu_expedite_current(struct srcu_struct *ssp)
 	raw_spin_unlock_irqrestore_rcu_node(sdp, flags);
 	// If needed, queue an expedited SRCU callback.
 	if (needcb)
-		__call_srcu(ssp, &sdp->srcu_ec_head, srcu_expedite_current_cb, false);
+		__call_srcu(ssp, &sdp->srcu_ec_head, srcu_expedite_current_cb,
+			    false, _RET_IP_);
 	migrate_enable();
 }
 EXPORT_SYMBOL_GPL(srcu_expedite_current);

--- a/kernel/rcu/tiny.c
+++ b/kernel/rcu/tiny.c
@@ -11,6 +11,8 @@
  */
 #include <linux/completion.h>
 #include <linux/interrupt.h>
+#include <linux/irq_work.h>
+#include <linux/llist.h>
 #include <linux/notifier.h>
 #include <linux/rcupdate_wait.h>
 #include <linux/kernel.h>
@@ -42,8 +44,36 @@ static struct rcu_ctrlblk rcu_ctrlblk = {
 	.gp_seq		= 0 - 300UL,
 };
 
+/*
+ * call_rcu() cannot be invoked from NMI context: its callback-queuing path
+ * runs under local_irq_save() (which does not mask NMIs) and appends to the
+ * callback list with a non-atomic multi-store that an NMI could corrupt.
+ *
+ * When called from NMI, stage the callback on a lockless list (llist_add() is
+ * a single cmpxchg and hence NMI-safe) and schedule an irq_work (its local
+ * enqueue is NMI-safe) that hands it to call_rcu_hurry() from ordinary context.
+ */
+static void rcu_nmi_drain(struct irq_work *iw);
+static LLIST_HEAD(rcu_nmi_list);
+static DEFINE_IRQ_WORK(rcu_nmi_iw, rcu_nmi_drain);
+
+static void rcu_nmi_drain(struct irq_work *iw)
+{
+	struct llist_node *node, *next;
+
+	/* llist_add() prepends, so reverse to preserve call_rcu() order. */
+	node = llist_reverse_order(llist_del_all(&rcu_nmi_list));
+	llist_for_each_safe(node, next, node) {
+		struct rcu_head *head = (struct rcu_head *)node;
+
+		call_rcu_hurry(head, head->func);
+	}
+}
+
 void rcu_barrier(void)
 {
+	/* Register any callbacks staged from NMI context first. */
+	irq_work_sync(&rcu_nmi_iw);
 	wait_rcu_gp(call_rcu_hurry);
 }
 EXPORT_SYMBOL(rcu_barrier);
@@ -159,6 +189,14 @@ void call_rcu(struct rcu_head *head, rcu_callback_t func)
 {
 	static atomic_t doublefrees;
 	unsigned long flags;
+
+	/* NMI callers cannot touch the callback list; defer via irq_work. */
+	if (in_nmi()) {
+		head->func = func;
+		if (llist_add((struct llist_node *)head, &rcu_nmi_list))
+			irq_work_queue(&rcu_nmi_iw);
+		return;
+	}
 
 	if (debug_rcu_head_queue(head)) {
 		if (atomic_inc_return(&doublefrees) < 4) {

--- a/kernel/rcu/tree.c
+++ b/kernel/rcu/tree.c
@@ -24,6 +24,7 @@
 #include <linux/smp.h>
 #include <linux/rcupdate_wait.h>
 #include <linux/interrupt.h>
+#include <linux/llist.h>
 #include <linux/sched.h>
 #include <linux/sched/debug.h>
 #include <linux/nmi.h>
@@ -3126,6 +3127,78 @@ static void check_cb_ovld(struct rcu_data *rdp)
 	raw_spin_unlock_rcu_node(rnp);
 }
 
+/*
+ * call_rcu() cannot be invoked from NMI context: its callback-queuing path
+ * runs under local_irq_save() (which does not mask NMIs) and appends to the
+ * per-CPU rcu_segcblist with a non-atomic multi-store and, on offloaded CPUs,
+ * a raw spinlock -- an NMI could corrupt the list or deadlock on the lock.
+ *
+ * When called from NMI, the callback is instead staged on a per-CPU lockless
+ * list -- llist_add() is a single cmpxchg and hence NMI-safe -- and an irq_work
+ * (its local enqueue is NMI-safe) hands it back to call_rcu_hurry() from
+ * ordinary context, where all of call_rcu()'s checks and machinery run
+ * normally.  The hurry flavor is used because a deferred callback has already
+ * incurred latency and should not be delayed further by lazy batching.
+ */
+struct rcu_nmi_queue {
+	struct llist_head	list;
+	struct irq_work		iw;
+};
+
+static void rcu_nmi_drain(struct irq_work *iw);
+
+static DEFINE_PER_CPU(struct rcu_nmi_queue, rcu_nmi_queue) = {
+	.list	= LLIST_HEAD_INIT(rcu_nmi_queue.list),
+	.iw	= IRQ_WORK_INIT(rcu_nmi_drain),
+};
+
+static atomic_long_t rcu_nmi_pending;
+
+static void rcu_nmi_drain(struct irq_work *iw)
+{
+	struct rcu_nmi_queue *rnq = container_of(iw, struct rcu_nmi_queue, iw);
+	struct llist_node *node, *next;
+
+	/* llist_add() prepends, so reverse to preserve call_rcu() order. */
+	node = llist_reverse_order(llist_del_all(&rnq->list));
+	llist_for_each_safe(node, next, node) {
+		struct rcu_head *head = (struct rcu_head *)node;
+
+		call_rcu_hurry(head, head->func);
+		atomic_long_dec(&rcu_nmi_pending);
+	}
+}
+
+/*
+ * Stage @head from NMI context; handed to call_rcu_hurry() from the irq_work.
+ * Called only with in_nmi() true, so the CPU is stable without preempt_disable.
+ */
+static void call_rcu_nmi(struct rcu_head *head, rcu_callback_t func)
+{
+	struct rcu_nmi_queue *rnq = this_cpu_ptr(&rcu_nmi_queue);
+
+	head->func = func;
+	atomic_long_inc(&rcu_nmi_pending);
+	if (llist_add((struct llist_node *)head, &rnq->list))
+		irq_work_queue(&rnq->iw);
+}
+
+/*
+ * Drain every CPU's NMI-staged callbacks into call_rcu() so that a following
+ * rcu_barrier() waits for them.  Callbacks staged on a CPU that has since gone
+ * offline were already drained by the irq_work flush during CPU teardown.  The
+ * pending count keeps this a single load when call_rcu() is never used in NMI.
+ */
+static void rcu_nmi_flush(void)
+{
+	int cpu;
+
+	if (!atomic_long_read(&rcu_nmi_pending))
+		return;
+	for_each_possible_cpu(cpu)
+		irq_work_sync(&per_cpu_ptr(&rcu_nmi_queue, cpu)->iw);
+}
+
 static void
 __call_rcu_common(struct rcu_head *head, rcu_callback_t func, bool lazy_in)
 {
@@ -3140,6 +3213,12 @@ __call_rcu_common(struct rcu_head *head, rcu_callback_t func, bool lazy_in)
 	/* Avoid NULL dereference if callback is NULL. */
 	if (WARN_ON_ONCE(!func))
 		return;
+
+	/* NMI callers cannot touch the segmented list or nocb locks; defer. */
+	if (in_nmi()) {
+		call_rcu_nmi(head, func);
+		return;
+	}
 
 	if (debug_rcu_head_queue(head)) {
 		/*
@@ -3849,8 +3928,18 @@ void rcu_barrier(void)
 	unsigned long flags;
 	unsigned long gseq;
 	struct rcu_data *rdp;
-	unsigned long s = rcu_seq_snap(&rcu_state.barrier_sequence);
+	unsigned long s;
 
+	/*
+	 * Hand any callbacks staged from NMI context to call_rcu() before
+	 * snapshotting the barrier sequence, so that they are covered whether
+	 * we do the barrier ourselves or piggyback on a concurrent one via the
+	 * early-exit path below (that barrier started after our flush, and so
+	 * observed the flushed callbacks).
+	 */
+	rcu_nmi_flush();
+
+	s = rcu_seq_snap(&rcu_state.barrier_sequence);
 	rcu_barrier_trace(TPS("Begin"), -1, s);
 
 	/* Take mutex to serialize concurrent rcu_barrier() requests. */


### PR DESCRIPTION
This RFC makes call_rcu() and call_srcu() safe to invoke from NMI
context, transparently: existing callers get NMI safety with no change
to calling code and no new API.

Motivation
==========

An increasing number of callers may run in NMI context and want to defer
work via RCU -- most notably BPF programs of type kprobe, perf_event, and
tracepoint, which can run in NMI and free objects that must wait for a
grace period.  Today they cannot:

  - call_rcu()'s enqueue runs under local_irq_save() (which masks
    hardirqs but not NMIs), appends to the per-CPU rcu_segcblist with a
    non-atomic multi-store, and on offloaded (rcu_nocb) CPUs takes
    per-CPU raw spinlocks.  An NMI can corrupt the list or self-deadlock
    on the lock.

  - call_srcu() has the same problem: srcu_gp_start_if_needed() runs
    under local_irq_save() and appends to the per-CPU srcu_cblist under a
    raw spinlock.

Subsystems have been open-coding "escape NMI/atomic context, then defer"
mechanisms to work around this (e.g. bpf_mem_alloc's free_by_rcu +
irq_work in kernel/bpf/memalloc.c, and arena_free_pages() in
kernel/bpf/arena.c).  Harry Yoo's kfree_rcu_nolock() series [1] adds
another, and its patch 3 defers call_rcu() via irq_work only when
!allow_spin && irqs_disabled(), with a comment stating the check "relies
on RCU's implementation details [and] should be removed once
call_rcu_nolock() is supported by the RCU subsystem."

Approach
========

Rather than add a new call_rcu*_nolock() API surface, make the existing
interfaces cope, as suggested by Paul McKenney: check in_nmi() inside
call_rcu()/call_srcu() and, when true, stage the callback on a per-CPU
lockless list (llist_add() is a single cmpxchg and hence NMI-safe) and
schedule an irq_work (its local enqueue is NMI-safe) that hands the
callback back to the ordinary call_rcu()/__call_srcu() from benign
(irq-work) context.

Because registration is still performed by the normal path, all of its
validation (debug-objects, KASAN, NULL/alignment checks) and the full
nocb/segcblist/SRCU machinery run unchanged.  The only cost to an NMI
caller is a small extra latency before the grace period begins.

in_nmi() is the precise discriminator here, not merely a cheap one: the
only way to interrupt call_rcu()/call_srcu()'s IRQ-disabled enqueue is an
NMI, so outside NMI the normal path is always safe.  This is strictly
tighter than the irqs_disabled() proxy, which needlessly defers in plain
hardirq / irqs-off contexts.  On the fast path it is a single
predicted-not-taken branch.

in_nmi() is also reliable for the callers that matter: the only window in
which it can report the wrong answer is between the hardware NMI entry and
nmi_enter() bumping preempt_count (and symmetrically at exit), and that
window is noinstr (exc_nmi()/default_do_nmi() are noinstr), so kprobes
and ftrace/BPF cannot attach there.  Every BPF-reachable NMI path runs
after nmi_enter(), where in_nmi() is true.

Barriers
--------

rcu_barrier() and srcu_barrier() must wait for callbacks staged from NMI.
Since a staged callback is not yet in any segmented list, each barrier
first drains every CPU's staged callbacks into the normal path (via
irq_work_sync()) before snapshotting its barrier sequence, so both the
self-barrier and early-exit (piggyback) paths cover them.  For call_rcu()
a pending count keeps this a single load when the NMI path is never used.

Callbacks staged on a CPU that goes offline before the irq_work runs are
drained by the irq_work flush performed during CPU teardown, so none are
stranded.

What this enables
=================

  - BPF programs in NMI can call_rcu()/call_rcu_tasks_trace() directly;
    in particular bpf_selem_unlink()'s in_nmi() bail-out in BPF local
    storage can be revisited.

  - In this tree call_rcu_tasks_trace() is call_srcu() on a dedicated
    srcu_struct, so making call_srcu() NMI-safe covers it for free --
    which is what sleepable BPF uses.

  - Harry's kfree_rcu_nolock() series can drop its irqs_disabled()-based
    deferral (patch 3) and submit full rcu sheaves with a plain
    call_rcu() from any context.

Testing
=======

Build-tested (arm64, TREE_RCU + TREE_SRCU + TASKS_TRACE_RCU): vmlinux and
all modules build and link cleanly.

The non-NMI paths are covered by the existing rcutorture "rcu" and
"tasks-tracing" flavors.  rcutorture does not itself invoke callbacks from
NMI, so exercising the in_nmi() path requires a separate harness (a perf
PMI overflow handler, or a self-IPI NMI on x86); help wanted on the best
way to fold NMI-context callback injection into rcutorture.

Open questions / limitations
============================

  - Scope: only TREE_RCU and TREE_SRCU are handled.  TINY_RCU / TINY_SRCU
    (UP) are left for a follow-up; is that acceptable, or should they be
    included from the start?

  - Should call_rcu()'s in_nmi() branch preserve the "hurry" flavor for
    call_rcu_hurry()-from-NMI (it currently drains via call_rcu(), which
    is lazy-capable), and preserve do_norm for call_srcu()?  Both are
    extreme edges today.

  - Is folding the deferral into the base interfaces preferred over an
    explicit call_rcu*_nolock() API?  An explicit-API version exists as a
    fallback if reviewers prefer callers to opt in.

[1] https://lore.kernel.org/linux-mm/20260720-kfree_rcu_nolock-v4-0-964e03c41a4e@kernel.org