### PR TITLE
selftests/bpf: Skip tracing_multi_bench_attach in CI

### DIFF
--- a/tools/testing/selftests/bpf/prog_tests/tracing_multi.c
+++ b/tools/testing/selftests/bpf/prog_tests/tracing_multi.c
@@ -679,6 +679,11 @@ void serial_test_tracing_multi_bench_attach(void)
 	struct btf *btf;
 	int err;
 
+	if (!test__is_explicit()) {
+		test__skip();
+		return;
+	}
+
 #ifndef __x86_64__
 	test__skip();
 	return;

--- a/tools/testing/selftests/bpf/test_progs.c
+++ b/tools/testing/selftests/bpf/test_progs.c
@@ -688,6 +688,11 @@ int test__join_cgroup(const char *path)
 	return fd;
 }
 
+bool test__is_explicit(void)
+{
+	return env.explicit_selection;
+}
+
 int bpf_find_map(const char *test, struct bpf_object *obj, const char *name)
 {
 	struct bpf_map *map;
@@ -1038,6 +1043,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case ARG_TEST_NUM: {
 		char *subtest_str = strchr(arg, '/');
 
+		env->explicit_selection = true;
 		if (subtest_str) {
 			*subtest_str = '\0';
 			if (parse_num_list(subtest_str + 1,
@@ -1057,6 +1063,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	}
 	case ARG_TEST_NAME_GLOB_ALLOWLIST:
 	case ARG_TEST_NAME: {
+		if (key == ARG_TEST_NAME)
+			env->explicit_selection = true;
 		if (arg[0] == '@')
 			err = parse_test_list_file(arg + 1,
 						   &env->test_selector.whitelist,

--- a/tools/testing/selftests/bpf/test_progs.h
+++ b/tools/testing/selftests/bpf/test_progs.h
@@ -105,6 +105,7 @@ struct test_env {
 	struct test_selector tmon_selector;
 	bool verifier_stats;
 	bool debug;
+	bool explicit_selection;
 	enum verbosity verbosity;
 
 	bool jit_enabled;
@@ -187,6 +188,7 @@ bool test__start_subtest(const char *name);
 void test__end_subtest(void);
 void test__skip(void);
 void test__fail(void);
+bool test__is_explicit(void);
 int test__join_cgroup(const char *path);
 void hexdump(const char *prefix, const void *buf, size_t len);
 


### PR DESCRIPTION
In CI, the tracing_multi_bench_attach test could cost >10s, which should be avoided in daily CI running.

 WATCHDOG: test case tracing_multi_bench_attach executes for 10 seconds...
 #546     tracing_multi_bench_attach:OK

Since it is for benchmark attachment of tracing_multi link, skip it in "-a" selection, and allow it in "-t"/"-n" selection.

 ./test_progs -a tracing_multi_bench_attach
 #546     tracing_multi_bench_attach:SKIP
 Summary: 1/0 PASSED, 1 SKIPPED, 0 FAILED