### PR TITLE
bpf: add BPF_F_LINK_SEALED flag to seal BPF links at creation

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -1931,6 +1931,14 @@ struct bpf_link {
 	 * link's semantics is determined by target attach hook
 	 */
 	bool sleepable;
+	/* Set from BPF_F_LINK_SEALED before the link is installed into the fd
+	 * table, and never cleared afterwards. A sealed link rejects
+	 * BPF_LINK_UPDATE and BPF_LINK_DETACH and holds a self-reference that
+	 * is never dropped, so it stays attached until the machine reboots.
+	 * Immutable once the link is reachable from user space, so readers
+	 * need no synchronization.
+	 */
+	bool sealed;
 };
 
 struct bpf_link_ops {

--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -1252,6 +1252,12 @@ enum bpf_perf_event_type {
 #define BPF_F_ID		(1U << 5)
 #define BPF_F_PREORDER		(1U << 6)
 #define BPF_F_LINK		BPF_F_LINK /* 1 << 13 */
+/* Create the link permanently sealed. Sealed links cannot be updated or
+ * detached and are never released, so they stay attached until reboot.
+ * Requires CAP_SYS_ADMIN. Only supported by link types that explicitly
+ * allow it; others reject the flag.
+ */
+#define BPF_F_LINK_SEALED	(1U << 31)
 
 /* If BPF_F_STRICT_ALIGNMENT is used in BPF_PROG_LOAD command, the
  * verifier will perform strict alignment checking as if the kernel

--- a/kernel/bpf/bpf_iter.c
+++ b/kernel/bpf/bpf_iter.c
@@ -512,7 +512,8 @@ int bpf_iter_link_attach(const union bpf_attr *attr, bpfptr_t uattr,
 	bpfptr_t ulinfo;
 	int err;
 
-	if (attr->link_create.target_fd || attr->link_create.flags)
+	if (attr->link_create.target_fd ||
+	    (attr->link_create.flags & ~BPF_F_LINK_SEALED))
 		return -EINVAL;
 
 	memset(&linfo, 0, sizeof(union bpf_iter_link_info));
@@ -554,6 +555,7 @@ int bpf_iter_link_attach(const union bpf_attr *attr, bpfptr_t uattr,
 
 	bpf_link_init(&link->link, BPF_LINK_TYPE_ITER, &bpf_iter_link_lops, prog,
 		      attr->link_create.attach_type);
+	link->link.sealed = attr->link_create.flags & BPF_F_LINK_SEALED;
 	link->tinfo = tinfo;
 
 	err = bpf_link_prime(&link->link, &link_primer);

--- a/kernel/bpf/cgroup.c
+++ b/kernel/bpf/cgroup.c
@@ -1544,7 +1544,7 @@ int cgroup_bpf_link_attach(const union bpf_attr *attr, struct bpf_prog *prog)
 	struct cgroup *cgrp;
 	int err;
 
-	if (attr->link_create.flags & (~BPF_F_LINK_ATTACH_MASK))
+	if (attr->link_create.flags & ~(BPF_F_LINK_ATTACH_MASK | BPF_F_LINK_SEALED))
 		return -EINVAL;
 
 	cgrp = cgroup_get_from_fd(attr->link_create.target_fd);
@@ -1558,6 +1558,7 @@ int cgroup_bpf_link_attach(const union bpf_attr *attr, struct bpf_prog *prog)
 	}
 	bpf_link_init(&link->link, BPF_LINK_TYPE_CGROUP, &bpf_cgroup_link_lops,
 		      prog, attr->link_create.attach_type);
+	link->link.sealed = attr->link_create.flags & BPF_F_LINK_SEALED;
 	link->cgroup = cgrp;
 
 	err = bpf_link_prime(&link->link, &link_primer);
@@ -1567,7 +1568,9 @@ int cgroup_bpf_link_attach(const union bpf_attr *attr, struct bpf_prog *prog)
 	}
 
 	err = cgroup_bpf_attach(cgrp, NULL, NULL, link,
-				link->link.attach_type, BPF_F_ALLOW_MULTI | attr->link_create.flags,
+				link->link.attach_type,
+				BPF_F_ALLOW_MULTI |
+				(attr->link_create.flags & ~BPF_F_LINK_SEALED),
 				attr->link_create.cgroup.relative_fd,
 				attr->link_create.cgroup.expected_revision);
 	if (err) {

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -3426,6 +3426,7 @@ static void bpf_link_show_fdinfo(struct seq_file *m, struct file *filp)
 		seq_printf(m, "link_type:\t<%u>\n", type);
 	}
 	seq_printf(m, "link_id:\t%u\n", link->id);
+	seq_printf(m, "sealed:\t%d\n", link->sealed ? 1 : 0);
 
 	rcu_read_lock();
 	prog = READ_ONCE(link->prog);
@@ -3532,6 +3533,13 @@ int bpf_link_prime(struct bpf_link *link, struct bpf_link_primer *primer)
 
 int bpf_link_settle(struct bpf_link_primer *primer)
 {
+	/* A sealed link keeps a reference to itself that is never dropped, so
+	 * it outlives every fd user space may hold. Taken here, before
+	 * fd_install() below publishes the link, so the link is already sealed
+	 * by the time user space can act on it.
+	 */
+	if (primer->link->sealed)
+		bpf_link_inc(primer->link);
 	/* make bpf_link fetchable by ID */
 	spin_lock_bh(&link_idr_lock);
 	primer->link->id = primer->id;
@@ -3635,7 +3643,8 @@ static int bpf_tracing_prog_attach(struct bpf_prog *prog,
 				   int tgt_prog_fd,
 				   u32 btf_id,
 				   u64 bpf_cookie,
-				   enum bpf_attach_type attach_type)
+				   enum bpf_attach_type attach_type,
+				   bool sealed)
 {
 	struct bpf_link_primer link_primer;
 	struct bpf_prog *tgt_prog = NULL;
@@ -3705,6 +3714,7 @@ static int bpf_tracing_prog_attach(struct bpf_prog *prog,
 	}
 	bpf_tramp_link_init(&link->link, BPF_LINK_TYPE_TRACING,
 			    &bpf_tracing_link_lops, prog, attach_type, bpf_cookie);
+	link->link.link.sealed = sealed;
 
 	if (prog->expected_attach_type == BPF_TRACE_FSESSION) {
 		link->fexit.link = &link->link.link;
@@ -4319,7 +4329,8 @@ static int bpf_raw_tp_link_attach(struct bpf_prog *prog,
 			tp_name = prog->aux->attach_func_name;
 			break;
 		}
-		return bpf_tracing_prog_attach(prog, 0, 0, 0, attach_type);
+		return bpf_tracing_prog_attach(prog, 0, 0, 0, attach_type,
+					       false);
 	case BPF_PROG_TYPE_RAW_TRACEPOINT:
 	case BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE:
 		if (strncpy_from_user(buf, user_tp_name, sizeof(buf) - 1) < 0)
@@ -5789,17 +5800,59 @@ err_put:
 	return err;
 }
 
+/* Link types that understand BPF_F_LINK_SEALED. Every other type either rejects
+ * unknown link_create flags outright or forwards them to an attach helper as
+ * type specific flags, so it must not be handed BPF_F_LINK_SEALED: honouring the
+ * flag there would need per-type plumbing, and ignoring it would silently
+ * hand back an unsealed link to a caller that asked for a sealed one.
+ */
+static bool link_seal_supported(const struct bpf_prog *prog)
+{
+	switch (prog->type) {
+	case BPF_PROG_TYPE_CGROUP_SKB:
+	case BPF_PROG_TYPE_CGROUP_SOCK:
+	case BPF_PROG_TYPE_CGROUP_SOCK_ADDR:
+	case BPF_PROG_TYPE_SOCK_OPS:
+	case BPF_PROG_TYPE_CGROUP_DEVICE:
+	case BPF_PROG_TYPE_CGROUP_SYSCTL:
+	case BPF_PROG_TYPE_CGROUP_SOCKOPT:
+		return true;
+	case BPF_PROG_TYPE_EXT:
+		return true;
+	case BPF_PROG_TYPE_LSM:
+	case BPF_PROG_TYPE_TRACING:
+		/* raw_tp and tracing_multi links do not carry the flag */
+		if (prog->expected_attach_type == BPF_TRACE_RAW_TP ||
+		    is_tracing_multi(prog->expected_attach_type))
+			return false;
+		return true;
+	default:
+		return false;
+	}
+}
+
 #define BPF_LINK_CREATE_LAST_FIELD link_create.uprobe_multi.path_fd
 static int link_create(union bpf_attr *attr, bpfptr_t uattr)
 {
+	bool sealed = attr->link_create.flags & BPF_F_LINK_SEALED;
 	struct bpf_prog *prog;
 	int ret;
 
 	if (CHECK_ATTR(BPF_LINK_CREATE))
 		return -EINVAL;
 
-	if (attr->link_create.attach_type == BPF_STRUCT_OPS)
+	/* Sealed links pin their program and themselves for the lifetime of
+	 * the system, so restrict the flag to the fully privileged.
+	 */
+	if (sealed && !capable(CAP_SYS_ADMIN))
+		return -EPERM;
+
+	if (attr->link_create.attach_type == BPF_STRUCT_OPS) {
+		/* struct_ops links do not validate link_create.flags */
+		if (sealed)
+			return -EOPNOTSUPP;
 		return bpf_struct_ops_link_create(attr);
+	}
 
 	prog = bpf_prog_get(attr->link_create.prog_fd);
 	if (IS_ERR(prog))
@@ -5809,6 +5862,11 @@ static int link_create(union bpf_attr *attr, bpfptr_t uattr)
 						attr->link_create.attach_type);
 	if (ret)
 		goto out;
+
+	if (sealed && !link_seal_supported(prog)) {
+		ret = -EOPNOTSUPP;
+		goto out;
+	}
 
 	switch (prog->type) {
 	case BPF_PROG_TYPE_CGROUP_SKB:
@@ -5825,7 +5883,8 @@ static int link_create(union bpf_attr *attr, bpfptr_t uattr)
 					      attr->link_create.target_fd,
 					      attr->link_create.target_btf_id,
 					      attr->link_create.tracing.cookie,
-					      attr->link_create.attach_type);
+					      attr->link_create.attach_type,
+					      sealed);
 		break;
 	case BPF_PROG_TYPE_LSM:
 	case BPF_PROG_TYPE_TRACING:
@@ -5847,7 +5906,8 @@ static int link_create(union bpf_attr *attr, bpfptr_t uattr)
 						      attr->link_create.target_fd,
 						      attr->link_create.target_btf_id,
 						      attr->link_create.tracing.cookie,
-						      attr->link_create.attach_type);
+						      attr->link_create.attach_type,
+						      sealed);
 		break;
 	case BPF_PROG_TYPE_FLOW_DISSECTOR:
 	case BPF_PROG_TYPE_SK_LOOKUP:
@@ -5945,6 +6005,11 @@ static int link_update(union bpf_attr *attr)
 	if (IS_ERR(link))
 		return PTR_ERR(link);
 
+	if (link->sealed) {
+		ret = -EPERM;
+		goto out_put_link;
+	}
+
 	if (link->ops->update_map) {
 		ret = link_update_map(link, attr);
 		goto out_put_link;
@@ -5997,7 +6062,9 @@ static int link_detach(union bpf_attr *attr)
 	if (IS_ERR(link))
 		return PTR_ERR(link);
 
-	if (link->ops->detach)
+	if (link->sealed)
+		ret = -EPERM;
+	else if (link->ops->detach)
 		ret = link->ops->detach(link);
 	else
 		ret = -EOPNOTSUPP;

--- a/tools/include/uapi/linux/bpf.h
+++ b/tools/include/uapi/linux/bpf.h
@@ -1252,6 +1252,12 @@ enum bpf_perf_event_type {
 #define BPF_F_ID		(1U << 5)
 #define BPF_F_PREORDER		(1U << 6)
 #define BPF_F_LINK		BPF_F_LINK /* 1 << 13 */
+/* Create the link permanently sealed. Sealed links cannot be updated or
+ * detached and are never released, so they stay attached until reboot.
+ * Requires CAP_SYS_ADMIN. Only supported by link types that explicitly
+ * allow it; others reject the flag.
+ */
+#define BPF_F_LINK_SEALED	(1U << 31)
 
 /* If BPF_F_STRICT_ALIGNMENT is used in BPF_PROG_LOAD command, the
  * verifier will perform strict alignment checking as if the kernel

--- a/tools/testing/selftests/bpf/prog_tests/link_seal.c
+++ b/tools/testing/selftests/bpf/prog_tests/link_seal.c
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2026 David Windsor */
+#include <test_progs.h>
+#include "test_link_seal.skel.h"
+
+/* Drop the self-reference held by a sealed link, via a bpf_testmod kfunc, so
+ * the link can be freed once its last fd goes away. Without this every run of
+ * this test would leak a link and its program until the machine reboots.
+ */
+static int force_unseal(struct test_link_seal *skel, int link_fd)
+{
+	struct { int link_fd; } args = { .link_fd = link_fd };
+	LIBBPF_OPTS(bpf_test_run_opts, opts,
+		.ctx_in = &args,
+		.ctx_size_in = sizeof(args),
+	);
+	int err;
+
+	err = bpf_prog_test_run_opts(bpf_program__fd(skel->progs.unseal_link),
+				     &opts);
+	if (err)
+		return err;
+	return opts.retval;
+}
+
+/* An unsealed link is still updatable and detachable. */
+static void test_unsealed_link(struct test_link_seal *skel)
+{
+	int link_fd, err;
+
+	link_fd = bpf_link_create(bpf_program__fd(skel->progs.dump_task), 0,
+				  BPF_TRACE_ITER, NULL);
+	if (!ASSERT_GE(link_fd, 0, "create"))
+		return;
+
+	err = bpf_link_update(link_fd, bpf_program__fd(skel->progs.dump_task_alt),
+			      NULL);
+	ASSERT_OK(err, "update");
+	close(link_fd);
+}
+
+/* A sealed link rejects update and detach, and survives its last fd. */
+static void test_sealed_link(struct test_link_seal *skel)
+{
+	LIBBPF_OPTS(bpf_link_create_opts, opts, .flags = BPF_F_LINK_SEALED);
+	struct bpf_link_info info = {};
+	__u32 len = sizeof(info);
+	int link_fd, fd, err, i;
+	__u32 id;
+
+	link_fd = bpf_link_create(bpf_program__fd(skel->progs.dump_task), 0,
+				  BPF_TRACE_ITER, &opts);
+	if (!ASSERT_GE(link_fd, 0, "create_sealed"))
+		return;
+
+	err = bpf_link_update(link_fd, bpf_program__fd(skel->progs.dump_task_alt),
+			      NULL);
+	ASSERT_EQ(err, -EPERM, "update_rejected");
+
+	err = bpf_link_detach(link_fd);
+	ASSERT_EQ(err, -EPERM, "detach_rejected");
+
+	err = bpf_link_get_info_by_fd(link_fd, &info, &len);
+	if (!ASSERT_OK(err, "get_info"))
+		goto cleanup;
+	id = info.id;
+
+	/* closing the last fd must not tear the link down */
+	close(link_fd);
+	link_fd = -1;
+
+	fd = bpf_link_get_fd_by_id(id);
+	if (!ASSERT_GE(fd, 0, "alive_after_close"))
+		return;
+
+	err = bpf_link_detach(fd);
+	ASSERT_EQ(err, -EPERM, "detach_rejected_after_close");
+
+	link_fd = fd;
+cleanup:
+	if (link_fd < 0)
+		return;
+
+	err = force_unseal(skel, link_fd);
+	if (!ASSERT_OK(err, "force_unseal")) {
+		close(link_fd);
+		return;
+	}
+
+	memset(&info, 0, sizeof(info));
+	len = sizeof(info);
+	err = bpf_link_get_info_by_fd(link_fd, &info, &len);
+	if (ASSERT_OK(err, "get_info_after_unseal"))
+		id = info.id;
+	close(link_fd);
+
+	/* the link is freed from a workqueue, so poll for it to disappear */
+	for (i = 0; i < 100; i++) {
+		fd = bpf_link_get_fd_by_id(id);
+		if (fd < 0)
+			break;
+		close(fd);
+		usleep(10000);
+	}
+	ASSERT_EQ(fd, -ENOENT, "freed_after_unseal");
+}
+
+/* Link types that cannot honour BPF_F_LINK_SEALED must reject it rather than
+ * quietly handing back an unsealed link.
+ */
+static void test_seal_unsupported(struct test_link_seal *skel)
+{
+	LIBBPF_OPTS(bpf_link_create_opts, opts, .flags = BPF_F_LINK_SEALED);
+	const char *syms[1] = { "bpf_fentry_test1" };
+	int link_fd;
+
+	opts.kprobe_multi.syms = syms;
+	opts.kprobe_multi.cnt = 1;
+
+	link_fd = bpf_link_create(bpf_program__fd(skel->progs.kprobe_multi_prog),
+				  0, BPF_TRACE_KPROBE_MULTI, &opts);
+	if (!ASSERT_LT(link_fd, 0, "kprobe_multi_seal_rejected")) {
+		close(link_fd);
+		return;
+	}
+	/* the central check in link_create() rejects the flag before
+	 * kprobe_multi ever sees it
+	 */
+	ASSERT_EQ(link_fd, -EOPNOTSUPP, "kprobe_multi_seal_err");
+}
+
+void test_link_seal(void)
+{
+	struct test_link_seal *skel;
+
+	skel = test_link_seal__open_and_load();
+	if (!ASSERT_OK_PTR(skel, "open_and_load"))
+		return;
+
+	if (test__start_subtest("unsealed"))
+		test_unsealed_link(skel);
+	if (test__start_subtest("sealed"))
+		test_sealed_link(skel);
+	if (test__start_subtest("unsupported"))
+		test_seal_unsupported(skel);
+
+	test_link_seal__destroy(skel);
+}

--- a/tools/testing/selftests/bpf/progs/test_link_seal.c
+++ b/tools/testing/selftests/bpf/progs/test_link_seal.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2026 David Windsor */
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include "../test_kmods/bpf_testmod_kfunc.h"
+
+char _license[] SEC("license") = "GPL";
+
+SEC("iter/task")
+int dump_task(struct bpf_iter__task *ctx)
+{
+	return 0;
+}
+
+SEC("iter/task")
+int dump_task_alt(struct bpf_iter__task *ctx)
+{
+	return 0;
+}
+
+SEC("kprobe.multi")
+int kprobe_multi_prog(struct pt_regs *ctx)
+{
+	return 0;
+}
+
+struct unseal_args {
+	int link_fd;
+};
+
+/* Test only: drop the self-reference a sealed link holds so the test can
+ * release the link instead of pinning it until the VM reboots.
+ */
+SEC("syscall")
+int unseal_link(struct unseal_args *ctx)
+{
+	return bpf_kfunc_link_force_unseal(ctx->link_fd);
+}

--- a/tools/testing/selftests/bpf/test_kmods/bpf_testmod.c
+++ b/tools/testing/selftests/bpf/test_kmods/bpf_testmod.c
@@ -1480,6 +1480,34 @@ __bpf_kfunc void bpf_kfunc_trigger_ctx_check(void)
 	irq_work_queue(&ctx_check_irq);
 }
 
+/* Test only: clear the sealed state of a link and drop the self-reference
+ * that sealing took, so selftests can free sealed links instead of pinning
+ * them until the machine reboots. The kernel deliberately offers no way to
+ * unseal a link.
+ */
+__bpf_kfunc int bpf_kfunc_link_force_unseal(int link_fd)
+{
+	struct bpf_link *link;
+
+	link = bpf_link_get_from_fd(link_fd);
+	if (IS_ERR(link))
+		return PTR_ERR(link);
+
+	if (!link->sealed) {
+		bpf_link_put(link);
+		return -EINVAL;
+	}
+
+	link->sealed = false;
+	/* Two puts: one for the reference sealing took, one for the lookup
+	 * above. The caller still holds link_fd, so the link cannot be freed
+	 * underneath us here.
+	 */
+	bpf_link_put(link);
+	bpf_link_put(link);
+	return 0;
+}
+
 BTF_KFUNCS_START(bpf_testmod_check_kfunc_ids)
 BTF_ID_FLAGS(func, bpf_testmod_test_mod_kfunc, KF_SPINLOCK_SAFE)
 BTF_ID_FLAGS(func, bpf_kfunc_call_test1)
@@ -1536,6 +1564,7 @@ BTF_ID_FLAGS(func, bpf_kfunc_implicit_arg, KF_IMPLICIT_ARGS)
 BTF_ID_FLAGS(func, bpf_kfunc_implicit_arg_legacy, KF_IMPLICIT_ARGS)
 BTF_ID_FLAGS(func, bpf_kfunc_implicit_arg_legacy_impl)
 BTF_ID_FLAGS(func, bpf_kfunc_trigger_ctx_check)
+BTF_ID_FLAGS(func, bpf_kfunc_link_force_unseal, KF_SLEEPABLE)
 BTF_KFUNCS_END(bpf_testmod_check_kfunc_ids)
 
 static int bpf_testmod_ops_init(struct btf *btf)
@@ -2200,3 +2229,4 @@ module_exit(bpf_testmod_exit);
 MODULE_AUTHOR("Andrii Nakryiko");
 MODULE_DESCRIPTION("BPF selftests module");
 MODULE_LICENSE("Dual BSD/GPL");
+MODULE_IMPORT_NS("BPF_INTERNAL");

--- a/tools/testing/selftests/bpf/test_kmods/bpf_testmod_kfunc.h
+++ b/tools/testing/selftests/bpf/test_kmods/bpf_testmod_kfunc.h
@@ -187,6 +187,8 @@ int bpf_kfunc_call_sock_sendmsg(struct sendmsg_args *args) __ksym;
 int bpf_kfunc_call_kernel_getsockname(struct addr_args *args) __ksym;
 int bpf_kfunc_call_kernel_getpeername(struct addr_args *args) __ksym;
 
+int bpf_kfunc_link_force_unseal(int link_fd) __ksym;
+
 void bpf_kfunc_dynptr_test(struct bpf_dynptr *ptr, struct bpf_dynptr *ptr__nullable) __ksym;
 
 struct bpf_testmod_ctx *bpf_testmod_ctx_create(int *err) __ksym;


### PR DESCRIPTION
CI test run for the BPF_F_LINK_SEALED series (v2), verifying the bpf_testmod
force-unseal kfunc used to release sealed links in selftests works correctly
under kernel-patches CI.

Not intended to be merged as-is; posted to bpf@vger.kernel.org.
